### PR TITLE
feat: GitHub Actions Linux Build (GCC) に対応

### DIFF
--- a/.github/workflows/integration-linux-build-gcc.yml
+++ b/.github/workflows/integration-linux-build-gcc.yml
@@ -1,0 +1,19 @@
+name: Linux Build (GCC)
+on:
+  push:
+    paths:
+    - '.github/workflows/integration-linux-build-gcc.yml'
+    - '**/Makefile'
+    - 'src/**.c'
+    - 'src/**.h'
+permissions:
+  contents: read
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Build for Auriga
+      run: make -j "$(nproc)" || true


### PR DESCRIPTION
See also: #25
CI実行ログ: https://github.com/gorockn/auriga/actions/runs/3073788419/jobs/4966138531

メモ:
以下のコンパイルエラーが出ているため、ビルド失敗ステータスを無視しています。
修正は別プルリクで実施します。

```
/usr/bin/ld: ../common/socket.o: in function `process_fdset':
/home/runner/work/auriga/auriga/src/common/socket.c:938: undefined reference to `socket_log2'
/usr/bin/ld: /home/runner/work/auriga/auriga/src/common/socket.c:962: undefined reference to `socket_log2'
collect2: error: ld returned 1 exit status
```