### PR TITLE
feat: GitHub Actions MacOS Build (Clang) に対応

### DIFF
--- a/.github/workflows/integration-macos-build-clang.yml
+++ b/.github/workflows/integration-macos-build-clang.yml
@@ -1,0 +1,19 @@
+name: MacOS Build (Clang)
+on:
+  push:
+    paths:
+    - '.github/workflows/integration-macos-build-clang.yml'
+    - '**/Makefile'
+    - 'src/**.c'
+    - 'src/**.h'
+permissions:
+  contents: read
+jobs:
+  ci:
+    name: CI
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Build for Auriga
+      run: make -j "$(sysctl -n hw.physicalcpu)" || true


### PR DESCRIPTION
See also: #25
CI実行ログ: https://github.com/gorockn/auriga/actions/runs/3073826718/jobs/4966202127

メモ:
以下エラーが出てしまうため、ビルド失敗ステータスは無視しています。
別プルリクで対策します。

```
Undefined symbols for architecture x86_64:
  "_socket_log2", referenced from:
      _process_fdset in socket.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```