### PR TITLE
fix: undefined reference to `socket_log2'コンパイルエラーの修正

### DIFF
--- a/src/common/socket.c
+++ b/src/common/socket.c
@@ -900,7 +900,7 @@ static void process_fdset(fd_set* rfd, fd_set* wfd)
 // Find the log base 2 of an N-bit integer in O(lg(N)) operations
 // in this case for 32bit input it would be 11 operations
 
-inline unsigned long socket_log2(unsigned long v)
+static inline unsigned long socket_log2(unsigned long v)
 {
 	register unsigned long c = 0;
 


### PR DESCRIPTION
`socket_log2` 関数の特性上、最適化オプションが有効な場合は
インライン展開されてほしいが、一方でデバッグオプションを
付与した場合は関数定義が残って欲しいケースがあると想定
(やっかいな問題になりがちなビット操作を行っているため)

本コミット時点では `GCC11` 環境にて `-std=c99` でビルドしており
C99における `static inline` は最適化オプション有無で挙動が変わるが
必ずインライン展開したい or 必ず関数シンボルを残したい場合は
以下の通り対応方法が異なるため、コミットログに明記しておく

- `static inline`
  - すべての関数call がインライン展開されると関数定義が消える
- `inline なしの宣言 + inline 付きの定義`
  - 関数定義は必ず残る
- inline
  - (C99の場合) 関数定義は必ず消える
- extern inline
  - (C99の場合) 関数定義は必ず残る

Reference: http://masahir0y.blogspot.com/2012/08/blog-post.html

See also: https://github.com/auriga/auriga/pull/28
See also: https://github.com/auriga/auriga/pull/29

CIログ(Windows/MSVC2019): https://github.com/gorockn/auriga/actions/runs/3073968704
CIログ (Windows/MSVC 2022): https://github.com/gorockn/auriga/actions/runs/3073968703
CIログ(Linux/GCC): https://github.com/gorockn/auriga/actions/runs/3073968707
CIログ(MacOS/Clang): https://github.com/gorockn/auriga/actions/runs/3073968706

メモ:
本プルリクでビルドエラーが解消されたので、別プルリクにて
Linux/MacOSのビルドステータスを必ずチェックするようにします。
（ついでにプルリク時のチェック有効化を忘れていたので、合わせて対策します）