### PR TITLE
Patch 1581

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ----------------------------------------
+//1581 [2025/05/23] by Gorockn
+
+・GCCコンパイル時の警告に対応（Makefile）
+　・`_BSD_SOURCE` を `_DEFAULT_SOURCE` に変更
+　・glibc 2.20以降は `_BSD_SOURCE` は非推奨のため
+
+----------------------------------------
 //1580 [2025/05/21] by gorockn
 
 ・Linux/GCCのビルドエラーを修正（utils.h, luascript.c, luascript.h, status.c, status.h）

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ else
     MAKE = make
 endif
 
-CFLAGS = -D_XOPEN_SOURCE -D_BSD_SOURCE -Wall -Wextra -I../common -I../common/lua $(PACKETDEF) $(OS_TYPE)
+CFLAGS = -D_XOPEN_SOURCE -D_DEFAULT_SOURCE -Wall -Wextra -I../common -I../common/lua $(PACKETDEF) $(OS_TYPE)
 LIBS = -lm
 
 #Link Zlib(NOTrecommended)


### PR DESCRIPTION
・GCCコンパイル時の警告に対応（Makefile）
　・`_BSD_SOURCE` を `_DEFAULT_SOURCE` に変更
　・glibc 2.20以降は `_BSD_SOURCE` は非推奨のため