### PR TITLE
clif.c: 0078/007b スパウンパケットの共通化

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -746,363 +746,1150 @@ static void clif_get_weapon_view(struct map_session_data* sd, int *rhand, int *l
 }
 
 /*==========================================
+ * 0078/007b spawn packet common builder
+ *------------------------------------------
+ */
+enum {
+	CLIF_SPAWN_STYLE_PC = 0,      /* PC / pcview packet ladder */
+	CLIF_SPAWN_STYLE_UNIT = 1,    /* monster/hom/merc/elem/npc ladder */
+	CLIF_SPAWN_STYLE_NPC_WALK = 2 /* npc007b only (modern 9fd branches) */
+};
+
+#define CLIF_SPAWN_F_MEMSET       0x01
+#define CLIF_SPAWN_F_WRITE_NAME   0x02
+#define CLIF_SPAWN_F_RAW_LEVEL    0x04 /* write level as WBUFW, not WBUFLV */
+#define CLIF_SPAWN_F_EMBLEM_LONG  0x08 /* emblem as WBUFL on old PC packets */
+#define CLIF_SPAWN_F_EMP_GUILD    0x10 /* EMP 1285-1287 old guild offsets */
+#define CLIF_SPAWN_F_NPC_GUILD    0x20 /* WARP_DEBUG triple guild write */
+#define CLIF_SPAWN_F_TYPE_AT_2    0x40 /* write objecttype at buf[2] (elem old) */
+#define CLIF_SPAWN_F_NPC_PCVIEW   0x80 /* npc pcview appearance fields */
+#define CLIF_SPAWN_F_MERC_TICK33  0x100 /* merc007b >=20180704 tick@33 quirk */
+
+struct clif_spawn_info {
+	int packet_style;
+	unsigned int flags;
+	int id;
+	int char_id;
+	unsigned short speed;
+	unsigned short opt1, opt2;
+	unsigned int option;
+	unsigned int opt3;
+	unsigned short view_class;
+	unsigned short hair;
+	unsigned int weapon;
+	unsigned int shield;
+	unsigned short head_bottom, head_top, head_mid;
+	unsigned short hair_color, clothes_color;
+	unsigned short head_dir;
+	unsigned short robe;
+	int guild_id;
+	unsigned short emblem_id;
+	unsigned short manner;
+	unsigned char karma;
+	unsigned char sex;
+	short x, y, to_x, to_y;
+	unsigned char dir;
+	unsigned char xsize, ysize;
+	unsigned char dead_sit;
+	unsigned short level;
+	unsigned short level_class;
+	unsigned short font;
+	unsigned short style;
+	const char *name;
+	unsigned char objecttype;
+	int class_id; /* for EMP guild check */
+};
+
+static void clif_spawn_set_guild(struct clif_spawn_info *info, int guild_id)
+{
+	info->guild_id = 0;
+	info->emblem_id = 0;
+	if(guild_id) {
+		struct guild *g = guild_search(guild_id);
+		info->guild_id = guild_id;
+		if(g)
+			info->emblem_id = (unsigned short)g->emblem_id;
+	}
+}
+
+static int clif_spawn_name_len(const struct clif_spawn_info *info)
+{
+	return (info->name) ? (int)strlen(info->name) : 0;
+}
+
+static void clif_spawn_write_level(unsigned char *buf, int pos, const struct clif_spawn_info *info)
+{
+	if(info->flags & CLIF_SPAWN_F_RAW_LEVEL)
+		WBUFW(buf,pos) = info->level;
+	else
+		WBUFLV(buf,pos,info->level,info->level_class);
+}
+
+static void clif_spawn_write_name(unsigned char *buf, int pos, const struct clif_spawn_info *info)
+{
+	if((info->flags & CLIF_SPAWN_F_WRITE_NAME) && info->name)
+		strncpy(WBUFP(buf,pos), info->name, 24);
+}
+
+static void clif_spawn_npc_guild78(unsigned char *buf, const struct clif_spawn_info *info)
+{
+	if(!(info->flags & CLIF_SPAWN_F_NPC_GUILD) || info->guild_id <= 0)
+		return;
+#if PACKETVER < 20071106
+	WBUFL(buf,26)=info->guild_id;
+	WBUFL(buf,36)=info->guild_id;
+	WBUFW(buf,40)=info->emblem_id;
+#elif PACKETVER < 20091104
+	WBUFL(buf,26)=info->guild_id;
+	WBUFL(buf,37)=info->guild_id;
+	WBUFW(buf,41)=info->emblem_id;
+#elif PACKETVER < 20110111
+	WBUFL(buf,31)=info->guild_id;
+	WBUFL(buf,39)=info->guild_id;
+	WBUFW(buf,43)=info->emblem_id;
+#elif PACKETVER < 20150513
+	WBUFL(buf,31)=info->guild_id;
+	WBUFL(buf,41)=info->guild_id;
+	WBUFW(buf,45)=info->emblem_id;
+#elif PACKETVER < 20180704
+	WBUFL(buf,35)=info->guild_id;
+	WBUFL(buf,45)=info->guild_id;
+	WBUFW(buf,49)=info->emblem_id;
+#else
+	WBUFL(buf,39)=info->guild_id;
+	WBUFL(buf,49)=info->guild_id;
+	WBUFW(buf,53)=info->emblem_id;
+#endif
+}
+
+/*==========================================
+ * standing (0078 family)
+ *------------------------------------------
+ */
+static int clif_spawn_build78(const struct clif_spawn_info *info, unsigned char *buf)
+{
+	int len;
+	int namelen;
+	int emp;
+
+	nullpo_retr(0, info);
+	nullpo_retr(0, buf);
+
+	namelen = clif_spawn_name_len(info);
+	emp = (info->flags & CLIF_SPAWN_F_EMP_GUILD) &&
+		(info->class_id == 1285 || info->class_id == 1286 || info->class_id == 1287) &&
+		info->guild_id;
+
+	if(info->packet_style == CLIF_SPAWN_STYLE_UNIT) {
+#if PACKETVER < 20071106
+		len = packet_db[0x78].len;
+		if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+		WBUFW(buf,0)=0x78;
+		WBUFL(buf,2)=info->id;
+		WBUFW(buf,6)=info->speed;
+		WBUFW(buf,8)=info->opt1;
+		WBUFW(buf,10)=info->opt2;
+		WBUFW(buf,12)=info->option;
+		WBUFW(buf,14)=info->view_class;
+		WBUFW(buf,16)=info->hair;
+		if(info->head_bottom)
+			WBUFW(buf,20)=info->head_bottom;
+		else
+			WBUFW(buf,20)=info->weapon;
+		if(emp) {
+			WBUFL(buf,22)=info->emblem_id;
+			WBUFL(buf,26)=info->guild_id;
+		}
+		WBUFW(buf,42)=info->opt3;
+		WBUFPOS(buf,46,info->x,info->y,info->dir);
+		WBUFB(buf,49)=info->xsize;
+		WBUFB(buf,50)=info->ysize;
+		clif_spawn_write_level(buf,52,info);
+		clif_spawn_npc_guild78(buf, info);
+		return len;
+#elif PACKETVER < 20091104
+		len = packet_db[0x78].len;
+		if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+		WBUFW(buf,0)=0x78;
+		if(info->flags & CLIF_SPAWN_F_TYPE_AT_2)
+			WBUFB(buf,2)=info->objecttype;
+		else
+			WBUFB(buf,2)=0;
+		WBUFL(buf,3)=info->id;
+		WBUFW(buf,7)=info->speed;
+		WBUFW(buf,9)=info->opt1;
+		WBUFW(buf,11)=info->opt2;
+		WBUFW(buf,13)=info->option;
+		WBUFW(buf,15)=info->view_class;
+		WBUFW(buf,17)=info->hair;
+		if(info->head_bottom)
+			WBUFW(buf,21)=info->head_bottom;
+		else
+			WBUFW(buf,21)=info->weapon;
+		if(emp) {
+			WBUFL(buf,23)=info->emblem_id;
+			WBUFL(buf,27)=info->guild_id;
+		}
+		WBUFW(buf,43)=info->opt3;
+		WBUFPOS(buf,47,info->x,info->y,info->dir);
+		WBUFB(buf,50)=info->xsize;
+		WBUFB(buf,51)=info->ysize;
+		/* mob non-pcview keeps LV at 52; others use 53 */
+		if(info->flags & CLIF_SPAWN_F_EMP_GUILD)
+			clif_spawn_write_level(buf,52,info);
+		else
+			clif_spawn_write_level(buf,53,info);
+		clif_spawn_npc_guild78(buf, info);
+		return len;
+#endif
+	}
+
+	/* PC style old, or UNIT/PC modern (>=20110111 shared layout) */
+#if PACKETVER < 4
+	if(info->packet_style == CLIF_SPAWN_STYLE_PC) {
+		len = packet_db[0x78].len;
+		if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+		WBUFW(buf,0)=0x78;
+		WBUFL(buf,2)=info->id;
+		WBUFW(buf,6)=info->speed;
+		WBUFW(buf,8)=info->opt1;
+		WBUFW(buf,10)=info->opt2;
+		WBUFW(buf,12)=info->option;
+		WBUFW(buf,14)=info->view_class;
+		WBUFW(buf,16)=info->hair;
+		WBUFW(buf,18)=info->weapon;
+		WBUFW(buf,20)=info->head_bottom;
+		WBUFW(buf,22)=info->shield;
+		WBUFW(buf,24)=info->head_top;
+		WBUFW(buf,26)=info->head_mid;
+		WBUFW(buf,28)=info->hair_color;
+		WBUFW(buf,30)=info->clothes_color;
+		WBUFW(buf,32)=info->head_dir;
+		WBUFL(buf,34)=info->guild_id;
+		WBUFL(buf,38)=info->emblem_id; /* PC <4 always long emblem */
+		WBUFW(buf,42)=info->manner;
+		WBUFB(buf,44)=info->karma;
+		WBUFB(buf,45)=info->sex;
+		WBUFPOS(buf,46,info->x,info->y,info->dir);
+		WBUFB(buf,49)=info->xsize;
+		WBUFB(buf,50)=info->ysize;
+		WBUFB(buf,51)=info->dead_sit;
+		clif_spawn_write_level(buf,52,info);
+		return len;
+	}
+#elif PACKETVER < 7
+	if(info->packet_style == CLIF_SPAWN_STYLE_PC) {
+		len = packet_db[0x1d8].len;
+		if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+		WBUFW(buf,0)=0x1d8;
+		WBUFL(buf,2)=info->id;
+		WBUFW(buf,6)=info->speed;
+		WBUFW(buf,8)=info->opt1;
+		WBUFW(buf,10)=info->opt2;
+		WBUFW(buf,12)=info->option;
+		WBUFW(buf,14)=info->view_class;
+		WBUFW(buf,16)=info->hair;
+		WBUFW(buf,18)=info->weapon;
+		WBUFW(buf,20)=info->shield;
+		WBUFW(buf,22)=info->head_bottom;
+		WBUFW(buf,24)=info->head_top;
+		WBUFW(buf,26)=info->head_mid;
+		WBUFW(buf,28)=info->hair_color;
+		WBUFW(buf,30)=info->clothes_color;
+		WBUFW(buf,32)=info->head_dir;
+		WBUFL(buf,34)=info->guild_id;
+		if(info->flags & CLIF_SPAWN_F_EMBLEM_LONG)
+			WBUFL(buf,38)=info->emblem_id;
+		else
+			WBUFW(buf,38)=info->emblem_id;
+		WBUFW(buf,40)=info->manner;
+		WBUFW(buf,42)=info->opt3;
+		WBUFB(buf,44)=info->karma;
+		WBUFB(buf,45)=info->sex;
+		WBUFPOS(buf,46,info->x,info->y,info->dir);
+		WBUFB(buf,49)=info->xsize;
+		WBUFB(buf,50)=info->ysize;
+		WBUFB(buf,51)=info->dead_sit;
+		clif_spawn_write_level(buf,52,info);
+		return len;
+	}
+#elif PACKETVER < 20080102
+	if(info->packet_style == CLIF_SPAWN_STYLE_PC) {
+		len = packet_db[0x22a].len;
+		if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+		WBUFW(buf,0)=0x22a;
+		WBUFL(buf,2)=info->id;
+		WBUFW(buf,6)=info->speed;
+		WBUFW(buf,8)=info->opt1;
+		WBUFW(buf,10)=info->opt2;
+		WBUFL(buf,12)=info->option;
+		WBUFW(buf,16)=info->view_class;
+		WBUFW(buf,18)=info->hair;
+		WBUFW(buf,20)=info->weapon;
+		WBUFW(buf,22)=info->shield;
+		WBUFW(buf,24)=info->head_bottom;
+		WBUFW(buf,26)=info->head_top;
+		WBUFW(buf,28)=info->head_mid;
+		WBUFW(buf,30)=info->hair_color;
+		WBUFW(buf,32)=info->clothes_color;
+		WBUFW(buf,34)=info->head_dir;
+		WBUFL(buf,36)=info->guild_id;
+		WBUFW(buf,40)=info->emblem_id;
+		WBUFW(buf,42)=info->manner;
+		WBUFL(buf,44)=info->opt3;
+		WBUFB(buf,48)=info->karma;
+		WBUFB(buf,49)=info->sex;
+		WBUFPOS(buf,50,info->x,info->y,info->dir);
+		WBUFB(buf,53)=info->xsize;
+		WBUFB(buf,54)=info->ysize;
+		WBUFB(buf,55)=info->dead_sit;
+		clif_spawn_write_level(buf,56,info);
+		return len;
+	}
+#elif PACKETVER < 20091104
+	if(info->packet_style == CLIF_SPAWN_STYLE_PC) {
+		len = packet_db[0x2ee].len;
+		if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+		WBUFW(buf,0)=0x2ee;
+		WBUFL(buf,2)=info->id;
+		WBUFW(buf,6)=info->speed;
+		WBUFW(buf,8)=info->opt1;
+		WBUFW(buf,10)=info->opt2;
+		WBUFL(buf,12)=info->option;
+		WBUFW(buf,16)=info->view_class;
+		WBUFW(buf,18)=info->hair;
+		WBUFW(buf,20)=info->weapon;
+		WBUFW(buf,22)=info->shield;
+		WBUFW(buf,24)=info->head_bottom;
+		WBUFW(buf,26)=info->head_top;
+		WBUFW(buf,28)=info->head_mid;
+		WBUFW(buf,30)=info->hair_color;
+		WBUFW(buf,32)=info->clothes_color;
+		WBUFW(buf,34)=info->head_dir;
+		WBUFL(buf,36)=info->guild_id;
+		WBUFW(buf,40)=info->emblem_id;
+		WBUFW(buf,42)=info->manner;
+		WBUFL(buf,44)=info->opt3;
+		WBUFB(buf,48)=info->karma;
+		WBUFB(buf,49)=info->sex;
+		WBUFPOS(buf,50,info->x,info->y,info->dir);
+		WBUFB(buf,53)=info->xsize;
+		WBUFB(buf,54)=info->ysize;
+		WBUFB(buf,55)=info->dead_sit;
+		clif_spawn_write_level(buf,56,info);
+		WBUFW(buf,58)=info->font;
+		return len;
+	}
+#elif PACKETVER < 20110111
+	/* PC and UNIT share 0x7f9 body; objecttype differs */
+	len = 63 + namelen;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x7f9;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFW(buf,9)=info->speed;
+	WBUFW(buf,11)=info->opt1;
+	WBUFW(buf,13)=info->opt2;
+	WBUFL(buf,15)=info->option;
+	WBUFW(buf,19)=info->view_class;
+	WBUFW(buf,21)=info->hair;
+	WBUFW(buf,23)=info->weapon;
+	WBUFW(buf,25)=info->shield;
+	WBUFW(buf,27)=info->head_bottom;
+	WBUFW(buf,29)=info->head_top;
+	WBUFW(buf,31)=info->head_mid;
+	WBUFW(buf,33)=info->hair_color;
+	WBUFW(buf,35)=info->clothes_color;
+	WBUFW(buf,37)=info->head_dir;
+	WBUFL(buf,39)=info->guild_id;
+	WBUFW(buf,43)=info->emblem_id;
+	WBUFW(buf,45)=info->manner;
+	WBUFL(buf,47)=info->opt3;
+	WBUFB(buf,51)=info->karma;
+	WBUFB(buf,52)=info->sex;
+	WBUFPOS(buf,53,info->x,info->y,info->dir);
+	WBUFB(buf,56)=info->xsize;
+	WBUFB(buf,57)=info->ysize;
+	WBUFB(buf,58)=info->dead_sit;
+	clif_spawn_write_level(buf,59,info);
+	WBUFW(buf,61)=info->font;
+	clif_spawn_write_name(buf,63,info);
+	clif_spawn_npc_guild78(buf, info);
+	return len;
+#elif PACKETVER < 20120328
+	len = 65 + namelen;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x857;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFW(buf,9)=info->speed;
+	WBUFW(buf,11)=info->opt1;
+	WBUFW(buf,13)=info->opt2;
+	WBUFL(buf,15)=info->option;
+	WBUFW(buf,19)=info->view_class;
+	WBUFW(buf,21)=info->hair;
+	WBUFW(buf,23)=info->weapon;
+	WBUFW(buf,25)=info->shield;
+	WBUFW(buf,27)=info->head_bottom;
+	WBUFW(buf,29)=info->head_top;
+	WBUFW(buf,31)=info->head_mid;
+	WBUFW(buf,33)=info->hair_color;
+	WBUFW(buf,35)=info->clothes_color;
+	WBUFW(buf,37)=info->head_dir;
+	WBUFW(buf,39)=info->robe;
+	WBUFL(buf,41)=info->guild_id;
+	WBUFW(buf,45)=info->emblem_id;
+	WBUFW(buf,47)=info->manner;
+	WBUFL(buf,49)=info->opt3;
+	WBUFB(buf,53)=info->karma;
+	WBUFB(buf,54)=info->sex;
+	WBUFPOS(buf,55,info->x,info->y,info->dir);
+	WBUFB(buf,58)=info->xsize;
+	WBUFB(buf,59)=info->ysize;
+	WBUFB(buf,60)=info->dead_sit;
+	clif_spawn_write_level(buf,61,info);
+	WBUFW(buf,63)=info->font;
+	clif_spawn_write_name(buf,65,info);
+	clif_spawn_npc_guild78(buf, info);
+	return len;
+#elif PACKETVER < 20131223
+	len = 74;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x915;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFW(buf,9)=info->speed;
+	WBUFW(buf,11)=info->opt1;
+	WBUFW(buf,13)=info->opt2;
+	WBUFL(buf,15)=info->option;
+	WBUFW(buf,19)=info->view_class;
+	WBUFW(buf,21)=info->hair;
+	WBUFW(buf,23)=info->weapon;
+	WBUFW(buf,25)=info->shield;
+	WBUFW(buf,27)=info->head_bottom;
+	WBUFW(buf,29)=info->head_top;
+	WBUFW(buf,31)=info->head_mid;
+	WBUFW(buf,33)=info->hair_color;
+	WBUFW(buf,35)=info->clothes_color;
+	WBUFW(buf,37)=info->head_dir;
+	WBUFW(buf,39)=info->robe;
+	WBUFL(buf,41)=info->guild_id;
+	WBUFW(buf,45)=info->emblem_id;
+	WBUFW(buf,47)=info->manner;
+	WBUFL(buf,49)=info->opt3;
+	WBUFB(buf,53)=info->karma;
+	WBUFB(buf,54)=info->sex;
+	WBUFPOS(buf,55,info->x,info->y,info->dir);
+	WBUFB(buf,58)=info->xsize;
+	WBUFB(buf,59)=info->ysize;
+	WBUFB(buf,60)=info->dead_sit;
+	clif_spawn_write_level(buf,61,info);
+	WBUFW(buf,63)=info->font;
+	WBUFL(buf,65)=0xffffffff;
+	WBUFL(buf,69)=0xffffffff;
+	WBUFB(buf,73)=0;
+	clif_spawn_npc_guild78(buf, info);
+	return len;
+#elif PACKETVER < 20150513
+	len = 78 + namelen;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x9dd;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFL(buf,9)=info->char_id;
+	WBUFW(buf,13)=info->speed;
+	WBUFW(buf,15)=info->opt1;
+	WBUFW(buf,17)=info->opt2;
+	WBUFL(buf,19)=info->option;
+	WBUFW(buf,23)=info->view_class;
+	WBUFW(buf,25)=info->hair;
+	WBUFW(buf,27)=info->weapon;
+	WBUFW(buf,29)=info->shield;
+	WBUFW(buf,31)=info->head_bottom;
+	WBUFW(buf,33)=info->head_top;
+	WBUFW(buf,35)=info->head_mid;
+	WBUFW(buf,37)=info->hair_color;
+	WBUFW(buf,39)=info->clothes_color;
+	WBUFW(buf,41)=info->head_dir;
+	WBUFW(buf,43)=info->robe;
+	WBUFL(buf,45)=info->guild_id;
+	WBUFW(buf,49)=info->emblem_id;
+	WBUFW(buf,51)=info->manner;
+	WBUFL(buf,53)=info->opt3;
+	WBUFB(buf,57)=info->karma;
+	WBUFB(buf,58)=info->sex;
+	WBUFPOS(buf,59,info->x,info->y,info->dir);
+	WBUFB(buf,62)=info->xsize;
+	WBUFB(buf,63)=info->ysize;
+	WBUFB(buf,64)=info->dead_sit;
+	clif_spawn_write_level(buf,65,info);
+	WBUFW(buf,67)=info->font;
+	WBUFL(buf,69)=0xffffffff;
+	WBUFL(buf,73)=0xffffffff;
+	WBUFB(buf,77)=0;
+	clif_spawn_write_name(buf,78,info);
+	clif_spawn_npc_guild78(buf, info);
+	return len;
+#elif PACKETVER < 20180704
+	len = 80 + namelen;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x9ff;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFL(buf,9)=info->char_id;
+	WBUFW(buf,13)=info->speed;
+	WBUFW(buf,15)=info->opt1;
+	WBUFW(buf,17)=info->opt2;
+	WBUFL(buf,19)=info->option;
+	WBUFW(buf,23)=info->view_class;
+	WBUFW(buf,25)=info->hair;
+	WBUFW(buf,27)=info->weapon;
+	WBUFW(buf,29)=info->shield;
+	WBUFW(buf,31)=info->head_bottom;
+	WBUFW(buf,33)=info->head_top;
+	WBUFW(buf,35)=info->head_mid;
+	WBUFW(buf,37)=info->hair_color;
+	WBUFW(buf,39)=info->clothes_color;
+	WBUFW(buf,41)=info->head_dir;
+	WBUFW(buf,43)=info->robe;
+	WBUFL(buf,45)=info->guild_id;
+	WBUFW(buf,49)=info->emblem_id;
+	WBUFW(buf,51)=info->manner;
+	WBUFL(buf,53)=info->opt3;
+	WBUFB(buf,57)=info->karma;
+	WBUFB(buf,58)=info->sex;
+	WBUFPOS(buf,59,info->x,info->y,info->dir);
+	WBUFB(buf,62)=info->xsize;
+	WBUFB(buf,63)=info->ysize;
+	WBUFB(buf,64)=info->dead_sit;
+	clif_spawn_write_level(buf,65,info);
+	WBUFW(buf,67)=info->font;
+	WBUFL(buf,69)=0xffffffff;
+	WBUFL(buf,73)=0xffffffff;
+	WBUFB(buf,77)=0;
+	WBUFW(buf,78)=info->style;
+	clif_spawn_write_name(buf,80,info);
+	clif_spawn_npc_guild78(buf, info);
+	return len;
+#else
+	len = 84 + namelen;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x9ff;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFL(buf,9)=info->char_id;
+	WBUFW(buf,13)=info->speed;
+	WBUFW(buf,15)=info->opt1;
+	WBUFW(buf,17)=info->opt2;
+	WBUFL(buf,19)=info->option;
+	WBUFW(buf,23)=info->view_class;
+	WBUFW(buf,25)=info->hair;
+	WBUFL(buf,27)=info->weapon;
+	WBUFL(buf,31)=info->shield;
+	WBUFW(buf,35)=info->head_bottom;
+	WBUFW(buf,37)=info->head_top;
+	WBUFW(buf,39)=info->head_mid;
+	WBUFW(buf,41)=info->hair_color;
+	WBUFW(buf,43)=info->clothes_color;
+	WBUFW(buf,45)=info->head_dir;
+	WBUFW(buf,47)=info->robe;
+	WBUFL(buf,49)=info->guild_id;
+	WBUFW(buf,53)=info->emblem_id;
+	WBUFW(buf,55)=info->manner;
+	WBUFL(buf,57)=info->opt3;
+	WBUFB(buf,61)=info->karma;
+	WBUFB(buf,62)=info->sex;
+	WBUFPOS(buf,63,info->x,info->y,info->dir);
+	WBUFB(buf,66)=info->xsize;
+	WBUFB(buf,67)=info->ysize;
+	WBUFB(buf,68)=info->dead_sit;
+	clif_spawn_write_level(buf,69,info);
+	WBUFW(buf,71)=info->font;
+	WBUFL(buf,73)=0xffffffff;
+	WBUFL(buf,77)=0xffffffff;
+	WBUFB(buf,81)=0;
+	WBUFW(buf,82)=info->style;
+	clif_spawn_write_name(buf,84,info);
+	clif_spawn_npc_guild78(buf, info);
+	return len;
+#endif
+	return 0;
+}
+
+/*==========================================
+ * walking (007b family)
+ *------------------------------------------
+ */
+static int clif_spawn_build7b(const struct clif_spawn_info *info, unsigned char *buf)
+{
+	int len;
+	int namelen;
+	int emp;
+	unsigned int tick;
+
+	nullpo_retr(0, info);
+	nullpo_retr(0, buf);
+
+	namelen = clif_spawn_name_len(info);
+	tick = gettick();
+	emp = (info->flags & CLIF_SPAWN_F_EMP_GUILD) &&
+		(info->class_id == 1285 || info->class_id == 1286 || info->class_id == 1287) &&
+		info->guild_id;
+
+	/* NPC walk: only modern 0x9fd branches from original npc007b */
+	if(info->packet_style == CLIF_SPAWN_STYLE_NPC_WALK) {
+#if PACKETVER < 20180704
+		len = 86 + namelen;
+		if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+		WBUFW(buf,0)=0x9fd;
+		WBUFW(buf,2)=(unsigned short)len;
+		WBUFB(buf,4)=info->objecttype;
+		WBUFL(buf,5)=info->id;
+		WBUFL(buf,9)=info->char_id;
+		WBUFW(buf,13)=info->speed;
+		WBUFL(buf,19)=info->option;
+		WBUFW(buf,23)=info->view_class;
+		if(info->flags & CLIF_SPAWN_F_NPC_PCVIEW) {
+			WBUFW(buf,25)=info->hair;
+			WBUFL(buf,27)=0;
+			WBUFL(buf,29)=0;
+			WBUFW(buf,31)=info->head_bottom;
+			WBUFW(buf,37)=info->head_top;
+			WBUFW(buf,39)=info->head_mid;
+			WBUFW(buf,41)=info->hair_color;
+			WBUFW(buf,43)=info->clothes_color;
+			WBUFW(buf,45)=info->head_dir;
+			WBUFW(buf,47)=info->robe;
+			WBUFB(buf,62)=info->sex;
+			WBUFW(buf,84)=info->style;
+		}
+		WBUFL(buf,33)=tick;
+		WBUFPOS2(buf,63,info->x,info->y,info->to_x,info->to_y,8,8);
+		WBUFL(buf,75)=0xffffffff;
+		WBUFL(buf,79)=0xffffffff;
+		WBUFB(buf,83)=0;
+		clif_spawn_write_name(buf,86,info);
+		return len;
+#else
+		len = 90 + namelen;
+		if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+		WBUFW(buf,0)=0x9fd;
+		WBUFW(buf,2)=(unsigned short)len;
+		WBUFB(buf,4)=info->objecttype;
+		WBUFL(buf,5)=info->id;
+		WBUFL(buf,9)=info->char_id;
+		WBUFW(buf,13)=info->speed;
+		WBUFL(buf,19)=info->option;
+		WBUFW(buf,23)=info->view_class;
+		if(info->flags & CLIF_SPAWN_F_NPC_PCVIEW) {
+			WBUFW(buf,25)=info->hair;
+			WBUFL(buf,27)=0;
+			WBUFL(buf,31)=0;
+			WBUFW(buf,35)=info->head_bottom;
+			WBUFW(buf,41)=info->head_top;
+			WBUFW(buf,43)=info->head_mid;
+			WBUFW(buf,45)=info->hair_color;
+			WBUFW(buf,47)=info->clothes_color;
+			WBUFW(buf,49)=info->head_dir;
+			WBUFW(buf,51)=info->robe;
+			WBUFB(buf,66)=info->sex;
+			WBUFW(buf,88)=info->style;
+		}
+		WBUFL(buf,37)=tick;
+		WBUFPOS2(buf,67,info->x,info->y,info->to_x,info->to_y,8,8);
+		WBUFL(buf,79)=0xffffffff;
+		WBUFL(buf,83)=0xffffffff;
+		WBUFB(buf,87)=0;
+		clif_spawn_write_name(buf,90,info);
+		return len;
+#endif
+	}
+
+	if(info->packet_style == CLIF_SPAWN_STYLE_UNIT) {
+#if PACKETVER < 20091104
+		len = packet_db[0x7b].len;
+		if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+		WBUFW(buf,0)=0x7b;
+		WBUFL(buf,2)=info->id;
+		WBUFW(buf,6)=info->speed;
+		WBUFW(buf,8)=info->opt1;
+		WBUFW(buf,10)=info->opt2;
+		WBUFW(buf,12)=info->option;
+		WBUFW(buf,14)=info->view_class;
+		WBUFW(buf,16)=info->hair;
+		if(info->weapon || info->head_bottom)
+			WBUFW(buf,20)=(info->weapon) ? info->weapon : info->head_bottom;
+		WBUFL(buf,22)=tick;
+		if(emp) {
+			WBUFL(buf,26)=info->emblem_id;
+			WBUFL(buf,30)=info->guild_id;
+		}
+		WBUFW(buf,46)=info->opt3;
+		WBUFPOS2(buf,50,info->x,info->y,info->to_x,info->to_y,8,8);
+		WBUFB(buf,56)=info->xsize;
+		WBUFB(buf,57)=info->ysize;
+		clif_spawn_write_level(buf,58,info);
+		return len;
+#endif
+		/* UNIT modern falls through to shared modern PC layout */
+	}
+
+	/* PC style ladder + shared modern for UNIT */
+#if PACKETVER < 4
+	len = packet_db[0x7b].len;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x7b;
+	WBUFL(buf,2)=info->id;
+	WBUFW(buf,6)=info->speed;
+	WBUFW(buf,8)=info->opt1;
+	WBUFW(buf,10)=info->opt2;
+	WBUFW(buf,12)=info->option;
+	WBUFW(buf,14)=info->view_class;
+	WBUFW(buf,16)=info->hair;
+	WBUFW(buf,18)=info->weapon;
+	WBUFW(buf,20)=info->head_bottom;
+	WBUFL(buf,22)=tick;
+	WBUFW(buf,26)=info->shield;
+	WBUFW(buf,28)=info->head_top;
+	WBUFW(buf,30)=info->head_mid;
+	WBUFW(buf,32)=info->hair_color;
+	WBUFW(buf,34)=info->clothes_color;
+	WBUFW(buf,36)=info->head_dir;
+	WBUFL(buf,38)=info->guild_id;
+	WBUFL(buf,42)=info->emblem_id;
+	WBUFW(buf,46)=info->manner;
+	WBUFB(buf,48)=info->karma;
+	WBUFB(buf,49)=info->sex;
+	WBUFPOS2(buf,50,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,56)=info->xsize;
+	WBUFB(buf,57)=info->ysize;
+	clif_spawn_write_level(buf,58,info);
+	return len;
+#elif PACKETVER < 7
+	len = packet_db[0x1da].len;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x1da;
+	WBUFL(buf,2)=info->id;
+	WBUFW(buf,6)=info->speed;
+	WBUFW(buf,8)=info->opt1;
+	WBUFW(buf,10)=info->opt2;
+	WBUFW(buf,12)=info->option;
+	WBUFW(buf,14)=info->view_class;
+	WBUFW(buf,16)=info->hair;
+	WBUFW(buf,18)=info->weapon;
+	WBUFW(buf,20)=info->shield;
+	WBUFW(buf,22)=info->head_bottom;
+	WBUFL(buf,24)=tick;
+	WBUFW(buf,28)=info->head_top;
+	WBUFW(buf,30)=info->head_mid;
+	WBUFW(buf,32)=info->hair_color;
+	WBUFW(buf,34)=info->clothes_color;
+	WBUFW(buf,36)=info->head_dir;
+	WBUFL(buf,38)=info->guild_id;
+	if(info->flags & CLIF_SPAWN_F_EMBLEM_LONG)
+		WBUFL(buf,42)=info->emblem_id;
+	else
+		WBUFW(buf,42)=info->emblem_id;
+	WBUFW(buf,44)=info->manner;
+	WBUFW(buf,46)=info->opt3;
+	WBUFB(buf,48)=info->karma;
+	WBUFB(buf,49)=info->sex;
+	WBUFPOS2(buf,50,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,56)=info->xsize;
+	WBUFB(buf,57)=info->ysize;
+	clif_spawn_write_level(buf,58,info);
+	return len;
+#elif PACKETVER < 20071106
+	len = packet_db[0x22c].len;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x22c;
+	WBUFL(buf,2)=info->id;
+	WBUFW(buf,6)=info->speed;
+	WBUFW(buf,8)=info->opt1;
+	WBUFW(buf,10)=info->opt2;
+	WBUFL(buf,12)=info->option;
+	WBUFW(buf,16)=info->view_class;
+	WBUFW(buf,18)=info->hair;
+	WBUFW(buf,20)=info->weapon;
+	WBUFW(buf,22)=info->shield;
+	WBUFW(buf,24)=info->head_bottom;
+	WBUFL(buf,26)=tick;
+	WBUFW(buf,30)=info->head_top;
+	WBUFW(buf,32)=info->head_mid;
+	WBUFW(buf,34)=info->hair_color;
+	WBUFW(buf,36)=info->clothes_color;
+	WBUFW(buf,38)=info->head_dir;
+	WBUFL(buf,40)=info->guild_id;
+	WBUFW(buf,44)=info->emblem_id;
+	WBUFW(buf,46)=info->manner;
+	WBUFL(buf,48)=info->opt3;
+	WBUFB(buf,52)=info->karma;
+	WBUFB(buf,53)=info->sex;
+	WBUFPOS2(buf,54,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,60)=info->xsize;
+	WBUFB(buf,61)=info->ysize;
+	clif_spawn_write_level(buf,62,info);
+	return len;
+#elif PACKETVER < 20080102
+	len = packet_db[0x22c].len;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x22c;
+	WBUFB(buf,2)=0;
+	WBUFL(buf,3)=info->id;
+	WBUFW(buf,7)=info->speed;
+	WBUFW(buf,9)=info->opt1;
+	WBUFW(buf,11)=info->opt2;
+	WBUFL(buf,13)=info->option;
+	WBUFW(buf,17)=info->view_class;
+	WBUFW(buf,19)=info->hair;
+	WBUFW(buf,21)=info->weapon;
+	WBUFW(buf,23)=info->shield;
+	WBUFW(buf,25)=info->head_bottom;
+	WBUFL(buf,27)=tick;
+	WBUFW(buf,31)=info->head_top;
+	WBUFW(buf,33)=info->head_mid;
+	WBUFW(buf,35)=info->hair_color;
+	WBUFW(buf,37)=info->clothes_color;
+	WBUFW(buf,39)=info->head_dir;
+	WBUFL(buf,41)=info->guild_id;
+	WBUFW(buf,45)=info->emblem_id;
+	WBUFW(buf,47)=info->manner;
+	WBUFL(buf,49)=info->opt3;
+	WBUFB(buf,53)=info->karma;
+	WBUFB(buf,54)=info->sex;
+	WBUFPOS2(buf,55,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,61)=info->xsize;
+	WBUFB(buf,62)=info->ysize;
+	clif_spawn_write_level(buf,63,info);
+	return len;
+#elif PACKETVER < 20091104
+	len = packet_db[0x2ec].len;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x2ec;
+	WBUFB(buf,2)=0;
+	WBUFL(buf,3)=info->id;
+	WBUFW(buf,7)=info->speed;
+	WBUFW(buf,9)=info->opt1;
+	WBUFW(buf,11)=info->opt2;
+	WBUFL(buf,13)=info->option;
+	WBUFW(buf,17)=info->view_class;
+	WBUFW(buf,19)=info->hair;
+	WBUFW(buf,21)=info->weapon;
+	WBUFW(buf,23)=info->shield;
+	WBUFW(buf,25)=info->head_bottom;
+	WBUFL(buf,27)=tick;
+	WBUFW(buf,31)=info->head_top;
+	WBUFW(buf,33)=info->head_mid;
+	WBUFW(buf,35)=info->hair_color;
+	WBUFW(buf,37)=info->clothes_color;
+	WBUFW(buf,39)=info->head_dir;
+	WBUFL(buf,41)=info->guild_id;
+	WBUFW(buf,45)=info->emblem_id;
+	WBUFW(buf,47)=info->manner;
+	WBUFL(buf,49)=info->opt3;
+	WBUFB(buf,53)=info->karma;
+	WBUFB(buf,54)=info->sex;
+	WBUFPOS2(buf,55,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,61)=info->xsize;
+	WBUFB(buf,62)=info->ysize;
+	clif_spawn_write_level(buf,63,info);
+	WBUFW(buf,65)=info->font;
+	return len;
+#elif PACKETVER < 20110111
+	len = 69 + namelen;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x7f7;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFW(buf,9)=info->speed;
+	WBUFW(buf,11)=info->opt1;
+	WBUFW(buf,13)=info->opt2;
+	WBUFL(buf,15)=info->option;
+	WBUFW(buf,19)=info->view_class;
+	WBUFW(buf,21)=info->hair;
+	WBUFW(buf,23)=info->weapon;
+	WBUFW(buf,25)=info->shield;
+	WBUFW(buf,27)=info->head_bottom;
+	WBUFL(buf,29)=tick;
+	WBUFW(buf,33)=info->head_top;
+	WBUFW(buf,35)=info->head_mid;
+	WBUFW(buf,37)=info->hair_color;
+	WBUFW(buf,39)=info->clothes_color;
+	WBUFW(buf,41)=info->head_dir;
+	WBUFL(buf,43)=info->guild_id;
+	WBUFW(buf,47)=info->emblem_id;
+	WBUFW(buf,49)=info->manner;
+	WBUFL(buf,51)=info->opt3;
+	WBUFB(buf,55)=info->karma;
+	WBUFB(buf,56)=info->sex;
+	WBUFPOS2(buf,57,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,63)=info->xsize;
+	WBUFB(buf,64)=info->ysize;
+	clif_spawn_write_level(buf,65,info);
+	WBUFW(buf,67)=info->font;
+	clif_spawn_write_name(buf,69,info);
+	return len;
+#elif PACKETVER < 20120328
+	len = 71 + namelen;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x856;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFW(buf,9)=info->speed;
+	WBUFW(buf,11)=info->opt1;
+	WBUFW(buf,13)=info->opt2;
+	WBUFL(buf,15)=info->option;
+	WBUFW(buf,19)=info->view_class;
+	WBUFW(buf,21)=info->hair;
+	WBUFW(buf,23)=info->weapon;
+	WBUFW(buf,25)=info->shield;
+	WBUFW(buf,27)=info->head_bottom;
+	WBUFL(buf,29)=tick;
+	WBUFW(buf,33)=info->head_top;
+	WBUFW(buf,35)=info->head_mid;
+	WBUFW(buf,37)=info->hair_color;
+	WBUFW(buf,39)=info->clothes_color;
+	WBUFW(buf,41)=info->head_dir;
+	WBUFW(buf,43)=info->robe;
+	WBUFL(buf,45)=info->guild_id;
+	WBUFW(buf,49)=info->emblem_id;
+	WBUFW(buf,51)=info->manner;
+	WBUFL(buf,53)=info->opt3;
+	WBUFB(buf,57)=info->karma;
+	WBUFB(buf,58)=info->sex;
+	WBUFPOS2(buf,59,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,65)=info->xsize;
+	WBUFB(buf,66)=info->ysize;
+	clif_spawn_write_level(buf,67,info);
+	WBUFW(buf,69)=info->font;
+	clif_spawn_write_name(buf,71,info);
+	return len;
+#elif PACKETVER < 20131223
+	len = 80;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x914;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFW(buf,9)=info->speed;
+	WBUFW(buf,11)=info->opt1;
+	WBUFW(buf,13)=info->opt2;
+	WBUFL(buf,15)=info->option;
+	WBUFW(buf,19)=info->view_class;
+	WBUFW(buf,21)=info->hair;
+	WBUFW(buf,23)=info->weapon;
+	WBUFW(buf,25)=info->shield;
+	WBUFW(buf,27)=info->head_bottom;
+	WBUFL(buf,29)=tick;
+	WBUFW(buf,33)=info->head_top;
+	WBUFW(buf,35)=info->head_mid;
+	WBUFW(buf,37)=info->hair_color;
+	WBUFW(buf,39)=info->clothes_color;
+	WBUFW(buf,41)=info->head_dir;
+	WBUFW(buf,43)=info->robe;
+	WBUFL(buf,45)=info->guild_id;
+	WBUFW(buf,49)=info->emblem_id;
+	WBUFW(buf,51)=info->manner;
+	WBUFL(buf,53)=info->opt3;
+	WBUFB(buf,57)=info->karma;
+	WBUFB(buf,58)=info->sex;
+	WBUFPOS2(buf,59,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,65)=info->xsize;
+	WBUFB(buf,66)=info->ysize;
+	clif_spawn_write_level(buf,67,info);
+	WBUFW(buf,69)=info->font;
+	WBUFL(buf,71)=0xffffffff;
+	WBUFL(buf,75)=0xffffffff;
+	WBUFB(buf,79)=0;
+	return len;
+#elif PACKETVER < 20150513
+	len = 84 + namelen;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x9db;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFL(buf,9)=info->char_id;
+	WBUFW(buf,13)=info->speed;
+	WBUFW(buf,15)=info->opt1;
+	WBUFW(buf,17)=info->opt2;
+	WBUFL(buf,19)=info->option;
+	WBUFW(buf,23)=info->view_class;
+	WBUFW(buf,25)=info->hair;
+	WBUFW(buf,27)=info->weapon;
+	WBUFW(buf,29)=info->shield;
+	WBUFW(buf,31)=info->head_bottom;
+	WBUFL(buf,33)=tick;
+	WBUFW(buf,37)=info->head_top;
+	WBUFW(buf,39)=info->head_mid;
+	WBUFW(buf,41)=info->hair_color;
+	WBUFW(buf,43)=info->clothes_color;
+	WBUFW(buf,45)=info->head_dir;
+	WBUFW(buf,47)=info->robe;
+	WBUFL(buf,49)=info->guild_id;
+	WBUFW(buf,53)=info->emblem_id;
+	WBUFW(buf,55)=info->manner;
+	WBUFL(buf,57)=info->opt3;
+	WBUFB(buf,61)=info->karma;
+	WBUFB(buf,62)=info->sex;
+	WBUFPOS2(buf,63,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,69)=info->xsize;
+	WBUFB(buf,70)=info->ysize;
+	clif_spawn_write_level(buf,71,info);
+	WBUFW(buf,73)=info->font;
+	WBUFL(buf,75)=0xffffffff;
+	WBUFL(buf,79)=0xffffffff;
+	WBUFB(buf,83)=0;
+	clif_spawn_write_name(buf,84,info);
+	return len;
+#elif PACKETVER < 20180704
+	len = 86 + namelen;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x9fd;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFL(buf,9)=info->char_id;
+	WBUFW(buf,13)=info->speed;
+	WBUFW(buf,15)=info->opt1;
+	WBUFW(buf,17)=info->opt2;
+	WBUFL(buf,19)=info->option;
+	WBUFW(buf,23)=info->view_class;
+	WBUFW(buf,25)=info->hair;
+	WBUFW(buf,27)=info->weapon;
+	WBUFW(buf,29)=info->shield;
+	WBUFW(buf,31)=info->head_bottom;
+	WBUFL(buf,33)=tick;
+	WBUFW(buf,37)=info->head_top;
+	WBUFW(buf,39)=info->head_mid;
+	WBUFW(buf,41)=info->hair_color;
+	WBUFW(buf,43)=info->clothes_color;
+	WBUFW(buf,45)=info->head_dir;
+	WBUFW(buf,47)=info->robe;
+	WBUFL(buf,49)=info->guild_id;
+	WBUFW(buf,53)=info->emblem_id;
+	WBUFW(buf,55)=info->manner;
+	WBUFL(buf,57)=info->opt3;
+	WBUFB(buf,61)=info->karma;
+	WBUFB(buf,62)=info->sex;
+	WBUFPOS2(buf,63,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,69)=info->xsize;
+	WBUFB(buf,70)=info->ysize;
+	clif_spawn_write_level(buf,71,info);
+	WBUFW(buf,73)=info->font;
+	WBUFL(buf,75)=0xffffffff;
+	WBUFL(buf,79)=0xffffffff;
+	WBUFB(buf,83)=0;
+	WBUFW(buf,84)=info->style;
+	clif_spawn_write_name(buf,86,info);
+	return len;
+#else
+	len = 90 + namelen;
+	if(info->flags & CLIF_SPAWN_F_MEMSET) memset(buf,0,len);
+	WBUFW(buf,0)=0x9fd;
+	WBUFW(buf,2)=(unsigned short)len;
+	WBUFB(buf,4)=info->objecttype;
+	WBUFL(buf,5)=info->id;
+	WBUFL(buf,9)=info->char_id;
+	WBUFW(buf,13)=info->speed;
+	WBUFW(buf,15)=info->opt1;
+	WBUFW(buf,17)=info->opt2;
+	WBUFL(buf,19)=info->option;
+	WBUFW(buf,23)=info->view_class;
+	WBUFW(buf,25)=info->hair;
+	WBUFL(buf,27)=info->weapon;
+	WBUFL(buf,31)=info->shield;
+	if(info->flags & CLIF_SPAWN_F_MERC_TICK33) {
+		/* merc007b quirk: tick at 33, skip head_bottom@35 and tick@37 */
+		WBUFL(buf,33)=tick;
+	} else {
+		WBUFW(buf,35)=info->head_bottom;
+		WBUFL(buf,37)=tick;
+	}
+	WBUFW(buf,41)=info->head_top;
+	WBUFW(buf,43)=info->head_mid;
+	WBUFW(buf,45)=info->hair_color;
+	WBUFW(buf,47)=info->clothes_color;
+	WBUFW(buf,49)=info->head_dir;
+	WBUFW(buf,51)=info->robe;
+	WBUFL(buf,53)=info->guild_id;
+	WBUFW(buf,57)=info->emblem_id;
+	WBUFW(buf,59)=info->manner;
+	WBUFL(buf,61)=info->opt3;
+	WBUFB(buf,65)=info->karma;
+	WBUFB(buf,66)=info->sex;
+	WBUFPOS2(buf,67,info->x,info->y,info->to_x,info->to_y,8,8);
+	WBUFB(buf,73)=info->xsize;
+	WBUFB(buf,74)=info->ysize;
+	clif_spawn_write_level(buf,75,info);
+	WBUFW(buf,77)=info->font;
+	WBUFL(buf,79)=0xffffffff;
+	WBUFL(buf,83)=0xffffffff;
+	WBUFB(buf,87)=0;
+	WBUFW(buf,88)=info->style;
+	clif_spawn_write_name(buf,90,info);
+	return len;
+#endif
+}
+
+/*==========================================
  *
  *------------------------------------------
  */
 static int clif_set0078(struct map_session_data *sd,unsigned char *buf)
 {
+	struct clif_spawn_info info;
 	int rhand = 0, lhand = 0;
 
 	nullpo_retr(0, sd);
 
 	clif_get_weapon_view(sd, &rhand, &lhand);
-
-#if PACKETVER < 4
-	WBUFW(buf,0)=0x78;
-	WBUFL(buf,2)=sd->bl.id;
-	WBUFW(buf,6)=sd->speed;
-	WBUFW(buf,8)=sd->sc.opt1;
-	WBUFW(buf,10)=sd->sc.opt2;
-	WBUFW(buf,12)=sd->sc.option;
-	WBUFW(buf,14)=sd->view_class;
-	WBUFW(buf,16)=sd->status.hair;
-	WBUFW(buf,18)=rhand;
-	WBUFW(buf,20)=sd->status.head_bottom;
-	WBUFW(buf,22)=lhand;
-	WBUFW(buf,24)=sd->status.head_top;
-	WBUFW(buf,26)=sd->status.head_mid;
-	WBUFW(buf,28)=sd->status.hair_color;
-	WBUFW(buf,30)=sd->status.clothes_color;
-	WBUFW(buf,32)=sd->head_dir;
-	WBUFL(buf,34)=sd->status.guild_id;
-	WBUFL(buf,38)=sd->guild_emblem_id;
-	WBUFW(buf,42)=sd->status.manner;
-	WBUFB(buf,44)=(unsigned char)sd->status.karma;
-	WBUFB(buf,45)=sd->sex;
-	WBUFPOS(buf,46,sd->bl.x,sd->bl.y,sd->dir);
-	WBUFB(buf,49)=5;
-	WBUFB(buf,50)=5;
-	WBUFB(buf,51)=sd->state.dead_sit;
-	WBUFLV(buf,52,sd->status.base_level,sd->status.class_);
-
-	return packet_db[0x78].len;
-#elif PACKETVER < 7
-	WBUFW(buf,0)=0x1d8;
-	WBUFL(buf,2)=sd->bl.id;
-	WBUFW(buf,6)=sd->speed;
-	WBUFW(buf,8)=sd->sc.opt1;
-	WBUFW(buf,10)=sd->sc.opt2;
-	WBUFW(buf,12)=sd->sc.option;
-	WBUFW(buf,14)=sd->view_class;
-	WBUFW(buf,16)=sd->status.hair;
-	WBUFW(buf,18)=rhand;
-	WBUFW(buf,20)=lhand;
-	WBUFW(buf,22)=sd->status.head_bottom;
-	WBUFW(buf,24)=sd->status.head_top;
-	WBUFW(buf,26)=sd->status.head_mid;
-	WBUFW(buf,28)=sd->status.hair_color;
-	WBUFW(buf,30)=sd->status.clothes_color;
-	WBUFW(buf,32)=sd->head_dir;
-	WBUFL(buf,34)=sd->status.guild_id;
-	WBUFW(buf,38)=sd->guild_emblem_id;
-	WBUFW(buf,40)=sd->status.manner;
-	WBUFW(buf,42)=sd->sc.opt3;
-	WBUFB(buf,44)=(unsigned char)sd->status.karma;
-	WBUFB(buf,45)=sd->sex;
-	WBUFPOS(buf,46,sd->bl.x,sd->bl.y,sd->dir);
-	WBUFB(buf,49)=5;
-	WBUFB(buf,50)=5;
-	WBUFB(buf,51)=sd->state.dead_sit;
-	WBUFLV(buf,52,sd->status.base_level,sd->status.class_);
-
-	return packet_db[0x1d8].len;
-#elif PACKETVER < 20080102
-	WBUFW(buf,0)=0x22a;
-	WBUFL(buf,2)=sd->bl.id;
-	WBUFW(buf,6)=sd->speed;
-	WBUFW(buf,8)=sd->sc.opt1;
-	WBUFW(buf,10)=sd->sc.opt2;
-	WBUFL(buf,12)=sd->sc.option;
-	WBUFW(buf,16)=sd->view_class;
-	WBUFW(buf,18)=sd->status.hair;
-	WBUFW(buf,20)=rhand;
-	WBUFW(buf,22)=lhand;
-	WBUFW(buf,24)=sd->status.head_bottom;
-	WBUFW(buf,26)=sd->status.head_top;
-	WBUFW(buf,28)=sd->status.head_mid;
-	WBUFW(buf,30)=sd->status.hair_color;
-	WBUFW(buf,32)=sd->status.clothes_color;
-	WBUFW(buf,34)=sd->head_dir;
-	WBUFL(buf,36)=sd->status.guild_id;
-	WBUFW(buf,40)=sd->guild_emblem_id;
-	WBUFW(buf,42)=sd->status.manner;
-	WBUFL(buf,44)=sd->sc.opt3;
-	WBUFB(buf,48)=(unsigned char)sd->status.karma;
-	WBUFB(buf,49)=sd->sex;
-	WBUFPOS(buf,50,sd->bl.x,sd->bl.y,sd->dir);
-	WBUFB(buf,53)=5;
-	WBUFB(buf,54)=5;
-	WBUFB(buf,55)=sd->state.dead_sit;
-	WBUFLV(buf,56,sd->status.base_level,sd->status.class_);
-
-	return packet_db[0x22a].len;
-#elif PACKETVER < 20091104
-	WBUFW(buf,0)=0x2ee;
-	WBUFL(buf,2)=sd->bl.id;
-	WBUFW(buf,6)=sd->speed;
-	WBUFW(buf,8)=sd->sc.opt1;
-	WBUFW(buf,10)=sd->sc.opt2;
-	WBUFL(buf,12)=sd->sc.option;
-	WBUFW(buf,16)=sd->view_class;
-	WBUFW(buf,18)=sd->status.hair;
-	WBUFW(buf,20)=rhand;
-	WBUFW(buf,22)=lhand;
-	WBUFW(buf,24)=sd->status.head_bottom;
-	WBUFW(buf,26)=sd->status.head_top;
-	WBUFW(buf,28)=sd->status.head_mid;
-	WBUFW(buf,30)=sd->status.hair_color;
-	WBUFW(buf,32)=sd->status.clothes_color;
-	WBUFW(buf,34)=sd->head_dir;
-	WBUFL(buf,36)=sd->status.guild_id;
-	WBUFW(buf,40)=sd->guild_emblem_id;
-	WBUFW(buf,42)=sd->status.manner;
-	WBUFL(buf,44)=sd->sc.opt3;
-	WBUFB(buf,48)=(unsigned char)sd->status.karma;
-	WBUFB(buf,49)=sd->sex;
-	WBUFPOS(buf,50,sd->bl.x,sd->bl.y,sd->dir);
-	WBUFB(buf,53)=5;
-	WBUFB(buf,54)=5;
-	WBUFB(buf,55)=sd->state.dead_sit;
-	WBUFLV(buf,56,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,58)=sd->status.font;
-
-	return packet_db[0x2ee].len;
-#elif PACKETVER < 20110111
-	WBUFW(buf,0)=0x7f9;
-	WBUFW(buf,2)=(unsigned short)(63 + strlen(sd->status.name));
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFW(buf,9)=sd->speed;
-	WBUFW(buf,11)=sd->sc.opt1;
-	WBUFW(buf,13)=sd->sc.opt2;
-	WBUFL(buf,15)=sd->sc.option;
-	WBUFW(buf,19)=sd->view_class;
-	WBUFW(buf,21)=sd->status.hair;
-	WBUFW(buf,23)=rhand;
-	WBUFW(buf,25)=lhand;
-	WBUFW(buf,27)=sd->status.head_bottom;
-	WBUFW(buf,29)=sd->status.head_top;
-	WBUFW(buf,31)=sd->status.head_mid;
-	WBUFW(buf,33)=sd->status.hair_color;
-	WBUFW(buf,35)=sd->status.clothes_color;
-	WBUFW(buf,37)=sd->head_dir;
-	WBUFL(buf,39)=sd->status.guild_id;
-	WBUFW(buf,43)=sd->guild_emblem_id;
-	WBUFW(buf,45)=sd->status.manner;
-	WBUFL(buf,47)=sd->sc.opt3;
-	WBUFB(buf,51)=(unsigned char)sd->status.karma;
-	WBUFB(buf,52)=sd->sex;
-	WBUFPOS(buf,53,sd->bl.x,sd->bl.y,sd->dir);
-	WBUFB(buf,56)=5;
-	WBUFB(buf,57)=5;
-	WBUFB(buf,58)=sd->state.dead_sit;
-	WBUFLV(buf,59,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,61)=sd->status.font;
-	strncpy(WBUFP(buf,63),sd->status.name,24);
-
-	return WBUFW(buf,2);
-#elif PACKETVER < 20120328
-	WBUFW(buf,0)=0x857;
-	WBUFW(buf,2)=(unsigned short)(65 + strlen(sd->status.name));
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFW(buf,9)=sd->speed;
-	WBUFW(buf,11)=sd->sc.opt1;
-	WBUFW(buf,13)=sd->sc.opt2;
-	WBUFL(buf,15)=sd->sc.option;
-	WBUFW(buf,19)=sd->view_class;
-	WBUFW(buf,21)=sd->status.hair;
-	WBUFW(buf,23)=rhand;
-	WBUFW(buf,25)=lhand;
-	WBUFW(buf,27)=sd->status.head_bottom;
-	WBUFW(buf,29)=sd->status.head_top;
-	WBUFW(buf,31)=sd->status.head_mid;
-	WBUFW(buf,33)=sd->status.hair_color;
-	WBUFW(buf,35)=sd->status.clothes_color;
-	WBUFW(buf,37)=sd->head_dir;
-	WBUFW(buf,39)=sd->status.robe;
-	WBUFL(buf,41)=sd->status.guild_id;
-	WBUFW(buf,45)=sd->guild_emblem_id;
-	WBUFW(buf,47)=sd->status.manner;
-	WBUFL(buf,49)=sd->sc.opt3;
-	WBUFB(buf,53)=(unsigned char)sd->status.karma;
-	WBUFB(buf,54)=sd->sex;
-	WBUFPOS(buf,55,sd->bl.x,sd->bl.y,sd->dir);
-	WBUFB(buf,58)=5;
-	WBUFB(buf,59)=5;
-	WBUFB(buf,60)=sd->state.dead_sit;
-	WBUFLV(buf,61,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,63)=sd->status.font;
-	strncpy(WBUFP(buf,65),sd->status.name,24);
-
-	return WBUFW(buf,2);
-#elif PACKETVER < 20131223
-	WBUFW(buf,0)=0x915;
-	WBUFW(buf,2)=74;
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFW(buf,9)=sd->speed;
-	WBUFW(buf,11)=sd->sc.opt1;
-	WBUFW(buf,13)=sd->sc.opt2;
-	WBUFL(buf,15)=sd->sc.option;
-	WBUFW(buf,19)=sd->view_class;
-	WBUFW(buf,21)=sd->status.hair;
-	WBUFW(buf,23)=rhand;
-	WBUFW(buf,25)=lhand;
-	WBUFW(buf,27)=sd->status.head_bottom;
-	WBUFW(buf,29)=sd->status.head_top;
-	WBUFW(buf,31)=sd->status.head_mid;
-	WBUFW(buf,33)=sd->status.hair_color;
-	WBUFW(buf,35)=sd->status.clothes_color;
-	WBUFW(buf,37)=sd->head_dir;
-	WBUFW(buf,39)=sd->status.robe;
-	WBUFL(buf,41)=sd->status.guild_id;
-	WBUFW(buf,45)=sd->guild_emblem_id;
-	WBUFW(buf,47)=sd->status.manner;
-	WBUFL(buf,49)=sd->sc.opt3;
-	WBUFB(buf,53)=(unsigned char)sd->status.karma;
-	WBUFB(buf,54)=sd->sex;
-	WBUFPOS(buf,55,sd->bl.x,sd->bl.y,sd->dir);
-	WBUFB(buf,58)=5;
-	WBUFB(buf,59)=5;
-	WBUFB(buf,60)=sd->state.dead_sit;
-	WBUFLV(buf,61,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,63)=sd->status.font;
-	WBUFL(buf,65) = 0xffffffff;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFB(buf,73) = 0;
-
-	return WBUFW(buf,2);
-#elif PACKETVER < 20150513
-	WBUFW(buf,0)=0x9dd;
-	WBUFW(buf,2)=(unsigned short)(78 + strlen(sd->status.name));
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFL(buf,9)=sd->char_id;
-	WBUFW(buf,13)=sd->speed;
-	WBUFW(buf,15)=sd->sc.opt1;
-	WBUFW(buf,17)=sd->sc.opt2;
-	WBUFL(buf,19)=sd->sc.option;
-	WBUFW(buf,23)=sd->view_class;
-	WBUFW(buf,25)=sd->status.hair;
-	WBUFW(buf,27)=rhand;
-	WBUFW(buf,29)=lhand;
-	WBUFW(buf,31)=sd->status.head_bottom;
-	WBUFW(buf,33)=sd->status.head_top;
-	WBUFW(buf,35)=sd->status.head_mid;
-	WBUFW(buf,37)=sd->status.hair_color;
-	WBUFW(buf,39)=sd->status.clothes_color;
-	WBUFW(buf,41)=sd->head_dir;
-	WBUFW(buf,43)=sd->status.robe;
-	WBUFL(buf,45)=sd->status.guild_id;
-	WBUFW(buf,49)=sd->guild_emblem_id;
-	WBUFW(buf,51)=sd->status.manner;
-	WBUFL(buf,53)=sd->sc.opt3;
-	WBUFB(buf,57)=(unsigned char)sd->status.karma;
-	WBUFB(buf,58)=sd->sex;
-	WBUFPOS(buf,59,sd->bl.x,sd->bl.y,sd->dir);
-	WBUFB(buf,62)=5;
-	WBUFB(buf,63)=5;
-	WBUFB(buf,64)=sd->state.dead_sit;
-	WBUFLV(buf,65,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,67)=sd->status.font;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	strncpy(WBUFP(buf,78),sd->status.name,24);
-
-	return WBUFW(buf,2);
-#elif PACKETVER < 20180704
-	WBUFW(buf,0)=0x9ff;
-	WBUFW(buf,2)=(unsigned short)(80 + strlen(sd->status.name));
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFL(buf,9)=sd->char_id;
-	WBUFW(buf,13)=sd->speed;
-	WBUFW(buf,15)=sd->sc.opt1;
-	WBUFW(buf,17)=sd->sc.opt2;
-	WBUFL(buf,19)=sd->sc.option;
-	WBUFW(buf,23)=sd->view_class;
-	WBUFW(buf,25)=sd->status.hair;
-	WBUFW(buf,27)=rhand;
-	WBUFW(buf,29)=lhand;
-	WBUFW(buf,31)=sd->status.head_bottom;
-	WBUFW(buf,33)=sd->status.head_top;
-	WBUFW(buf,35)=sd->status.head_mid;
-	WBUFW(buf,37)=sd->status.hair_color;
-	WBUFW(buf,39)=sd->status.clothes_color;
-	WBUFW(buf,41)=sd->head_dir;
-	WBUFW(buf,43)=sd->status.robe;
-	WBUFL(buf,45)=sd->status.guild_id;
-	WBUFW(buf,49)=sd->guild_emblem_id;
-	WBUFW(buf,51)=sd->status.manner;
-	WBUFL(buf,53)=sd->sc.opt3;
-	WBUFB(buf,57)=(unsigned char)sd->status.karma;
-	WBUFB(buf,58)=sd->sex;
-	WBUFPOS(buf,59,sd->bl.x,sd->bl.y,sd->dir);
-	WBUFB(buf,62)=5;
-	WBUFB(buf,63)=5;
-	WBUFB(buf,64)=sd->state.dead_sit;
-	WBUFLV(buf,65,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,67)=sd->status.font;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	WBUFW(buf,78) = sd->status.style;
-	strncpy(WBUFP(buf,80),sd->status.name,24);
-
-	return WBUFW(buf,2);
-#else
-	WBUFW(buf,0)=0x9ff;
-	WBUFW(buf,2)=(unsigned short)(84 + strlen(sd->status.name));
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFL(buf,9)=sd->char_id;
-	WBUFW(buf,13)=sd->speed;
-	WBUFW(buf,15)=sd->sc.opt1;
-	WBUFW(buf,17)=sd->sc.opt2;
-	WBUFL(buf,19)=sd->sc.option;
-	WBUFW(buf,23)=sd->view_class;
-	WBUFW(buf,25)=sd->status.hair;
-	WBUFL(buf,27)=rhand;
-	WBUFL(buf,31)=lhand;
-	WBUFW(buf,35)=sd->status.head_bottom;
-	WBUFW(buf,37)=sd->status.head_top;
-	WBUFW(buf,39)=sd->status.head_mid;
-	WBUFW(buf,41)=sd->status.hair_color;
-	WBUFW(buf,43)=sd->status.clothes_color;
-	WBUFW(buf,45)=sd->head_dir;
-	WBUFW(buf,47)=sd->status.robe;
-	WBUFL(buf,49)=sd->status.guild_id;
-	WBUFW(buf,53)=sd->guild_emblem_id;
-	WBUFW(buf,55)=sd->status.manner;
-	WBUFL(buf,57)=sd->sc.opt3;
-	WBUFB(buf,61)=(unsigned char)sd->status.karma;
-	WBUFB(buf,62)=sd->sex;
-	WBUFPOS(buf,63,sd->bl.x,sd->bl.y,sd->dir);
-	WBUFB(buf,66)=5;
-	WBUFB(buf,67)=5;
-	WBUFB(buf,68)=sd->state.dead_sit;
-	WBUFLV(buf,69,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,71)=sd->status.font;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFL(buf,77) = 0xffffffff;
-	WBUFB(buf,81) = 0;
-	WBUFW(buf,82) = sd->status.style;
-	strncpy(WBUFP(buf,84),sd->status.name,24);
-
-	return WBUFW(buf,2);
-#endif
+	memset(&info, 0, sizeof(info));
+	info.packet_style = CLIF_SPAWN_STYLE_PC;
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME;
+	info.id = sd->bl.id;
+	info.char_id = sd->char_id;
+	info.speed = sd->speed;
+	info.opt1 = sd->sc.opt1;
+	info.opt2 = sd->sc.opt2;
+	info.option = sd->sc.option;
+	info.opt3 = sd->sc.opt3;
+	info.view_class = sd->view_class;
+	info.hair = sd->status.hair;
+	info.weapon = rhand;
+	info.shield = lhand;
+	info.head_bottom = sd->status.head_bottom;
+	info.head_top = sd->status.head_top;
+	info.head_mid = sd->status.head_mid;
+	info.hair_color = sd->status.hair_color;
+	info.clothes_color = sd->status.clothes_color;
+	info.head_dir = sd->head_dir;
+	info.robe = sd->status.robe;
+	info.guild_id = sd->status.guild_id;
+	info.emblem_id = sd->guild_emblem_id;
+	info.manner = sd->status.manner;
+	info.karma = (unsigned char)sd->status.karma;
+	info.sex = sd->sex;
+	info.x = sd->bl.x;
+	info.y = sd->bl.y;
+	info.dir = (unsigned char)sd->dir;
+	info.xsize = 5;
+	info.ysize = 5;
+	info.dead_sit = sd->state.dead_sit;
+	info.level = sd->status.base_level;
+	info.level_class = sd->status.class_;
+	info.font = sd->status.font;
+	info.style = sd->status.style;
+	info.name = sd->status.name;
+	return clif_spawn_build78(&info, buf);
 }
 
 /*==========================================
@@ -1111,395 +1898,59 @@ static int clif_set0078(struct map_session_data *sd,unsigned char *buf)
  */
 static int clif_set007b(struct map_session_data *sd,unsigned char *buf)
 {
+	struct clif_spawn_info info;
 	int rhand = 0, lhand = 0;
-	unsigned int tick = gettick();
 
 	nullpo_retr(0, sd);
 
 	clif_get_weapon_view(sd, &rhand, &lhand);
-
-#if PACKETVER < 4
-	WBUFW(buf,0)=0x7b;
-	WBUFL(buf,2)=sd->bl.id;
-	WBUFW(buf,6)=sd->speed;
-	WBUFW(buf,8)=sd->sc.opt1;
-	WBUFW(buf,10)=sd->sc.opt2;
-	WBUFW(buf,12)=sd->sc.option;
-	WBUFW(buf,14)=sd->view_class;
-	WBUFW(buf,16)=sd->status.hair;
-	WBUFW(buf,18)=rhand;
-	WBUFW(buf,20)=sd->status.head_bottom;
-	WBUFL(buf,22)=tick;
-	WBUFW(buf,26)=lhand;
-	WBUFW(buf,28)=sd->status.head_top;
-	WBUFW(buf,30)=sd->status.head_mid;
-	WBUFW(buf,32)=sd->status.hair_color;
-	WBUFW(buf,34)=sd->status.clothes_color;
-	WBUFW(buf,36)=sd->head_dir;
-	WBUFL(buf,38)=sd->status.guild_id;
-	WBUFL(buf,42)=sd->guild_emblem_id;
-	WBUFW(buf,46)=sd->status.manner;
-	WBUFB(buf,48)=(unsigned char)sd->status.karma;
-	WBUFB(buf,49)=sd->sex;
-	WBUFPOS2(buf,50,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,56)=5;
-	WBUFB(buf,57)=5;
-	WBUFLV(buf,58,sd->status.base_level,sd->status.class_);
-
-	return packet_db[0x7b].len;
-#elif PACKETVER < 7
-	WBUFW(buf,0)=0x1da;
-	WBUFL(buf,2)=sd->bl.id;
-	WBUFW(buf,6)=sd->speed;
-	WBUFW(buf,8)=sd->sc.opt1;
-	WBUFW(buf,10)=sd->sc.opt2;
-	WBUFW(buf,12)=sd->sc.option;
-	WBUFW(buf,14)=sd->view_class;
-	WBUFW(buf,16)=sd->status.hair;
-	WBUFW(buf,18)=rhand;
-	WBUFW(buf,20)=lhand;
-	WBUFW(buf,22)=sd->status.head_bottom;
-	WBUFL(buf,24)=tick;
-	WBUFW(buf,28)=sd->status.head_top;
-	WBUFW(buf,30)=sd->status.head_mid;
-	WBUFW(buf,32)=sd->status.hair_color;
-	WBUFW(buf,34)=sd->status.clothes_color;
-	WBUFW(buf,36)=sd->head_dir;
-	WBUFL(buf,38)=sd->status.guild_id;
-	WBUFW(buf,42)=sd->guild_emblem_id;
-	WBUFW(buf,44)=sd->status.manner;
-	WBUFW(buf,46)=sd->sc.opt3;
-	WBUFB(buf,48)=(unsigned char)sd->status.karma;
-	WBUFB(buf,49)=sd->sex;
-	WBUFPOS2(buf,50,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,56)=5;
-	WBUFB(buf,57)=5;
-	WBUFLV(buf,58,sd->status.base_level,sd->status.class_);
-
-	return packet_db[0x1da].len;
-#elif PACKETVER < 20071106
-	WBUFW(buf,0)=0x22c;
-	WBUFL(buf,2)=sd->bl.id;
-	WBUFW(buf,6)=sd->speed;
-	WBUFW(buf,8)=sd->sc.opt1;
-	WBUFW(buf,10)=sd->sc.opt2;
-	WBUFL(buf,12)=sd->sc.option;
-	WBUFW(buf,16)=sd->view_class;
-	WBUFW(buf,18)=sd->status.hair;
-	WBUFW(buf,20)=rhand;
-	WBUFW(buf,22)=lhand;
-	WBUFW(buf,24)=sd->status.head_bottom;
-	WBUFL(buf,26)=tick;
-	WBUFW(buf,30)=sd->status.head_top;
-	WBUFW(buf,32)=sd->status.head_mid;
-	WBUFW(buf,34)=sd->status.hair_color;
-	WBUFW(buf,36)=sd->status.clothes_color;
-	WBUFW(buf,38)=sd->head_dir;
-	WBUFL(buf,40)=sd->status.guild_id;
-	WBUFW(buf,44)=sd->guild_emblem_id;
-	WBUFW(buf,46)=sd->status.manner;
-	WBUFL(buf,48)=sd->sc.opt3;
-	WBUFB(buf,52)=(unsigned char)sd->status.karma;
-	WBUFB(buf,53)=sd->sex;
-	WBUFPOS2(buf,54,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,60)=0;
-	WBUFB(buf,61)=0;
-	WBUFLV(buf,62,sd->status.base_level,sd->status.class_);
-
-	return packet_db[0x22c].len;
-#elif PACKETVER < 20080102
-	WBUFW(buf,0)=0x22c;
-	WBUFB(buf,2)=0;
-	WBUFL(buf,3)=sd->bl.id;
-	WBUFW(buf,7)=sd->speed;
-	WBUFW(buf,9)=sd->sc.opt1;
-	WBUFW(buf,11)=sd->sc.opt2;
-	WBUFL(buf,13)=sd->sc.option;
-	WBUFW(buf,17)=sd->view_class;
-	WBUFW(buf,19)=sd->status.hair;
-	WBUFW(buf,21)=rhand;
-	WBUFW(buf,23)=lhand;
-	WBUFW(buf,25)=sd->status.head_bottom;
-	WBUFL(buf,27)=tick;
-	WBUFW(buf,31)=sd->status.head_top;
-	WBUFW(buf,33)=sd->status.head_mid;
-	WBUFW(buf,35)=sd->status.hair_color;
-	WBUFW(buf,37)=sd->status.clothes_color;
-	WBUFW(buf,39)=sd->head_dir;
-	WBUFL(buf,41)=sd->status.guild_id;
-	WBUFW(buf,45)=sd->guild_emblem_id;
-	WBUFW(buf,47)=sd->status.manner;
-	WBUFL(buf,49)=sd->sc.opt3;
-	WBUFB(buf,53)=(unsigned char)sd->status.karma;
-	WBUFB(buf,54)=sd->sex;
-	WBUFPOS2(buf,55,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,61)=0;
-	WBUFB(buf,62)=0;
-	WBUFLV(buf,63,sd->status.base_level,sd->status.class_);
-
-	return packet_db[0x22c].len;
-#elif PACKETVER < 20091104
-	WBUFW(buf,0)=0x2ec;
-	WBUFB(buf,2)=0;
-	WBUFL(buf,3)=sd->bl.id;
-	WBUFW(buf,7)=sd->speed;
-	WBUFW(buf,9)=sd->sc.opt1;
-	WBUFW(buf,11)=sd->sc.opt2;
-	WBUFL(buf,13)=sd->sc.option;
-	WBUFW(buf,17)=sd->view_class;
-	WBUFW(buf,19)=sd->status.hair;
-	WBUFW(buf,21)=rhand;
-	WBUFW(buf,23)=lhand;
-	WBUFW(buf,25)=sd->status.head_bottom;
-	WBUFL(buf,27)=tick;
-	WBUFW(buf,31)=sd->status.head_top;
-	WBUFW(buf,33)=sd->status.head_mid;
-	WBUFW(buf,35)=sd->status.hair_color;
-	WBUFW(buf,37)=sd->status.clothes_color;
-	WBUFW(buf,39)=sd->head_dir;
-	WBUFL(buf,41)=sd->status.guild_id;
-	WBUFW(buf,45)=sd->guild_emblem_id;
-	WBUFW(buf,47)=sd->status.manner;
-	WBUFL(buf,49)=sd->sc.opt3;
-	WBUFB(buf,53)=(unsigned char)sd->status.karma;
-	WBUFB(buf,54)=sd->sex;
-	WBUFPOS2(buf,55,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,61)=0;
-	WBUFB(buf,62)=0;
-	WBUFLV(buf,63,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,65)=sd->status.font;
-
-	return packet_db[0x2ec].len;
-#elif PACKETVER < 20110111
-	WBUFW(buf,0)=0x7f7;
-	WBUFW(buf,2)=(unsigned short)(69 + strlen(sd->status.name));
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFW(buf,9)=sd->speed;
-	WBUFW(buf,11)=sd->sc.opt1;
-	WBUFW(buf,13)=sd->sc.opt2;
-	WBUFL(buf,15)=sd->sc.option;
-	WBUFW(buf,19)=sd->view_class;
-	WBUFW(buf,21)=sd->status.hair;
-	WBUFW(buf,23)=rhand;
-	WBUFW(buf,25)=lhand;
-	WBUFW(buf,27)=sd->status.head_bottom;
-	WBUFL(buf,29)=tick;
-	WBUFW(buf,33)=sd->status.head_top;
-	WBUFW(buf,35)=sd->status.head_mid;
-	WBUFW(buf,37)=sd->status.hair_color;
-	WBUFW(buf,39)=sd->status.clothes_color;
-	WBUFW(buf,41)=sd->head_dir;
-	WBUFL(buf,43)=sd->status.guild_id;
-	WBUFW(buf,47)=sd->guild_emblem_id;
-	WBUFW(buf,49)=sd->status.manner;
-	WBUFL(buf,51)=sd->sc.opt3;
-	WBUFB(buf,55)=(unsigned char)sd->status.karma;
-	WBUFB(buf,56)=sd->sex;
-	WBUFPOS2(buf,57,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,63)=5;
-	WBUFB(buf,64)=5;
-	WBUFLV(buf,65,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,67)=sd->status.font;
-	strncpy(WBUFP(buf,69),sd->status.name,24);
-
-	return WBUFW(buf,2);
-#elif PACKETVER < 20120328
-	WBUFW(buf,0)=0x856;
-	WBUFW(buf,2)=(unsigned short)(71 + strlen(sd->status.name));
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFW(buf,9)=sd->speed;
-	WBUFW(buf,11)=sd->sc.opt1;
-	WBUFW(buf,13)=sd->sc.opt2;
-	WBUFL(buf,15)=sd->sc.option;
-	WBUFW(buf,19)=sd->view_class;
-	WBUFW(buf,21)=sd->status.hair;
-	WBUFW(buf,23)=rhand;
-	WBUFW(buf,25)=lhand;
-	WBUFW(buf,27)=sd->status.head_bottom;
-	WBUFL(buf,29)=tick;
-	WBUFW(buf,33)=sd->status.head_top;
-	WBUFW(buf,35)=sd->status.head_mid;
-	WBUFW(buf,37)=sd->status.hair_color;
-	WBUFW(buf,39)=sd->status.clothes_color;
-	WBUFW(buf,41)=sd->head_dir;
-	WBUFW(buf,43)=sd->status.robe;
-	WBUFL(buf,45)=sd->status.guild_id;
-	WBUFW(buf,49)=sd->guild_emblem_id;
-	WBUFW(buf,51)=sd->status.manner;
-	WBUFL(buf,53)=sd->sc.opt3;
-	WBUFB(buf,57)=(unsigned char)sd->status.karma;
-	WBUFB(buf,58)=sd->sex;
-	WBUFPOS2(buf,59,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,65)=5;
-	WBUFB(buf,66)=5;
-	WBUFLV(buf,67,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,69)=sd->status.font;
-	strncpy(WBUFP(buf,71),sd->status.name,24);
-
-	return WBUFW(buf,2);
-#elif PACKETVER < 20131223
-	WBUFW(buf,0)=0x914;
-	WBUFW(buf,2)=80;
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFW(buf,9)=sd->speed;
-	WBUFW(buf,11)=sd->sc.opt1;
-	WBUFW(buf,13)=sd->sc.opt2;
-	WBUFL(buf,15)=sd->sc.option;
-	WBUFW(buf,19)=sd->view_class;
-	WBUFW(buf,21)=sd->status.hair;
-	WBUFW(buf,23)=rhand;
-	WBUFW(buf,25)=lhand;
-	WBUFW(buf,27)=sd->status.head_bottom;
-	WBUFL(buf,29)=tick;
-	WBUFW(buf,33)=sd->status.head_top;
-	WBUFW(buf,35)=sd->status.head_mid;
-	WBUFW(buf,37)=sd->status.hair_color;
-	WBUFW(buf,39)=sd->status.clothes_color;
-	WBUFW(buf,41)=sd->head_dir;
-	WBUFW(buf,43)=sd->status.robe;
-	WBUFL(buf,45)=sd->status.guild_id;
-	WBUFW(buf,49)=sd->guild_emblem_id;
-	WBUFW(buf,51)=sd->status.manner;
-	WBUFL(buf,53)=sd->sc.opt3;
-	WBUFB(buf,57)=(unsigned char)sd->status.karma;
-	WBUFB(buf,58)=sd->sex;
-	WBUFPOS2(buf,59,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,65)=5;
-	WBUFB(buf,66)=5;
-	WBUFLV(buf,67,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,69)=sd->status.font;
-	WBUFL(buf,71)=0xffffffff;
-	WBUFL(buf,75)=0xffffffff;
-	WBUFB(buf,79)=0;
-
-	return WBUFW(buf,2);
-#elif PACKETVER < 20150513
-	WBUFW(buf,0)=0x9db;
-	WBUFW(buf,2)=(unsigned short)(84 + strlen(sd->status.name));
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFL(buf,9)=sd->char_id;
-	WBUFW(buf,13)=sd->speed;
-	WBUFW(buf,15)=sd->sc.opt1;
-	WBUFW(buf,17)=sd->sc.opt2;
-	WBUFL(buf,19)=sd->sc.option;
-	WBUFW(buf,23)=sd->view_class;
-	WBUFW(buf,25)=sd->status.hair;
-	WBUFW(buf,27)=rhand;
-	WBUFW(buf,29)=lhand;
-	WBUFW(buf,31)=sd->status.head_bottom;
-	WBUFL(buf,33)=tick;
-	WBUFW(buf,37)=sd->status.head_top;
-	WBUFW(buf,39)=sd->status.head_mid;
-	WBUFW(buf,41)=sd->status.hair_color;
-	WBUFW(buf,43)=sd->status.clothes_color;
-	WBUFW(buf,45)=sd->head_dir;
-	WBUFW(buf,47)=sd->status.robe;
-	WBUFL(buf,49)=sd->status.guild_id;
-	WBUFW(buf,53)=sd->guild_emblem_id;
-	WBUFW(buf,55)=sd->status.manner;
-	WBUFL(buf,57)=sd->sc.opt3;
-	WBUFB(buf,61)=(unsigned char)sd->status.karma;
-	WBUFB(buf,62)=sd->sex;
-	WBUFPOS2(buf,63,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,69)=5;
-	WBUFB(buf,70)=5;
-	WBUFLV(buf,71,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,73)=sd->status.font;
-	WBUFL(buf,75)=0xffffffff;
-	WBUFL(buf,79)=0xffffffff;
-	WBUFB(buf,83)=0;
-	strncpy(WBUFP(buf,84),sd->status.name,24);
-
-	return WBUFW(buf,2);
-#elif PACKETVER < 20180704
-	WBUFW(buf,0)=0x9fd;
-	WBUFW(buf,2)=(unsigned short)(86 + strlen(sd->status.name));
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFL(buf,9)=sd->char_id;
-	WBUFW(buf,13)=sd->speed;
-	WBUFW(buf,15)=sd->sc.opt1;
-	WBUFW(buf,17)=sd->sc.opt2;
-	WBUFL(buf,19)=sd->sc.option;
-	WBUFW(buf,23)=sd->view_class;
-	WBUFW(buf,25)=sd->status.hair;
-	WBUFW(buf,27)=rhand;
-	WBUFW(buf,29)=lhand;
-	WBUFW(buf,31)=sd->status.head_bottom;
-	WBUFL(buf,33)=tick;
-	WBUFW(buf,37)=sd->status.head_top;
-	WBUFW(buf,39)=sd->status.head_mid;
-	WBUFW(buf,41)=sd->status.hair_color;
-	WBUFW(buf,43)=sd->status.clothes_color;
-	WBUFW(buf,45)=sd->head_dir;
-	WBUFW(buf,47)=sd->status.robe;
-	WBUFL(buf,49)=sd->status.guild_id;
-	WBUFW(buf,53)=sd->guild_emblem_id;
-	WBUFW(buf,55)=sd->status.manner;
-	WBUFL(buf,57)=sd->sc.opt3;
-	WBUFB(buf,61)=(unsigned char)sd->status.karma;
-	WBUFB(buf,62)=sd->sex;
-	WBUFPOS2(buf,63,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,69)=5;
-	WBUFB(buf,70)=5;
-	WBUFLV(buf,71,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,73)=sd->status.font;
-	WBUFL(buf,75)=0xffffffff;
-	WBUFL(buf,79)=0xffffffff;
-	WBUFB(buf,83)=0;
-	WBUFW(buf,84)=sd->status.style;
-	strncpy(WBUFP(buf,86),sd->status.name,24);
-
-	return WBUFW(buf,2);
+	memset(&info, 0, sizeof(info));
+	info.packet_style = CLIF_SPAWN_STYLE_PC;
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME;
+	info.id = sd->bl.id;
+	info.char_id = sd->char_id;
+	info.speed = sd->speed;
+	info.opt1 = sd->sc.opt1;
+	info.opt2 = sd->sc.opt2;
+	info.option = sd->sc.option;
+	info.opt3 = sd->sc.opt3;
+	info.view_class = sd->view_class;
+	info.hair = sd->status.hair;
+	info.weapon = rhand;
+	info.shield = lhand;
+	info.head_bottom = sd->status.head_bottom;
+	info.head_top = sd->status.head_top;
+	info.head_mid = sd->status.head_mid;
+	info.hair_color = sd->status.hair_color;
+	info.clothes_color = sd->status.clothes_color;
+	info.head_dir = sd->head_dir;
+	info.robe = sd->status.robe;
+	info.guild_id = sd->status.guild_id;
+	info.emblem_id = sd->guild_emblem_id;
+	info.manner = sd->status.manner;
+	info.karma = (unsigned char)sd->status.karma;
+	info.sex = sd->sex;
+	info.x = sd->bl.x;
+	info.y = sd->bl.y;
+	info.to_x = sd->ud.to_x;
+	info.to_y = sd->ud.to_y;
+#if PACKETVER < 7 || PACKETVER >= 20110111
+	info.xsize = 5;
+	info.ysize = 5;
 #else
-	WBUFW(buf,0)=0x9fd;
-	WBUFW(buf,2)=(unsigned short)(90 + strlen(sd->status.name));
-	WBUFB(buf,4)=0;
-	WBUFL(buf,5)=sd->bl.id;
-	WBUFL(buf,9)=sd->char_id;
-	WBUFW(buf,13)=sd->speed;
-	WBUFW(buf,15)=sd->sc.opt1;
-	WBUFW(buf,17)=sd->sc.opt2;
-	WBUFL(buf,19)=sd->sc.option;
-	WBUFW(buf,23)=sd->view_class;
-	WBUFW(buf,25)=sd->status.hair;
-	WBUFL(buf,27)=rhand;
-	WBUFL(buf,31)=lhand;
-	WBUFW(buf,35)=sd->status.head_bottom;
-	WBUFL(buf,37)=tick;
-	WBUFW(buf,41)=sd->status.head_top;
-	WBUFW(buf,43)=sd->status.head_mid;
-	WBUFW(buf,45)=sd->status.hair_color;
-	WBUFW(buf,47)=sd->status.clothes_color;
-	WBUFW(buf,49)=sd->head_dir;
-	WBUFW(buf,51)=sd->status.robe;
-	WBUFL(buf,53)=sd->status.guild_id;
-	WBUFW(buf,57)=sd->guild_emblem_id;
-	WBUFW(buf,59)=sd->status.manner;
-	WBUFL(buf,61)=sd->sc.opt3;
-	WBUFB(buf,65)=(unsigned char)sd->status.karma;
-	WBUFB(buf,66)=sd->sex;
-	WBUFPOS2(buf,67,sd->bl.x,sd->bl.y,sd->ud.to_x,sd->ud.to_y,8,8);
-	WBUFB(buf,73)=5;
-	WBUFB(buf,74)=5;
-	WBUFLV(buf,75,sd->status.base_level,sd->status.class_);
-	WBUFW(buf,77)=sd->status.font;
-	WBUFL(buf,79)=0xffffffff;
-	WBUFL(buf,83)=0xffffffff;
-	WBUFB(buf,87)=0;
-	WBUFW(buf,88)=sd->status.style;
-	strncpy(WBUFP(buf,90),sd->status.name,24);
-
-	return WBUFW(buf,2);
+	info.xsize = 0;
+	info.ysize = 0;
 #endif
+	info.level = sd->status.base_level;
+	info.level_class = sd->status.class_;
+	info.font = sd->status.font;
+	info.style = sd->status.style;
+	info.name = sd->status.name;
+	return clif_spawn_build7b(&info, buf);
 }
 
 /*==========================================
- * クラスチェンジ typeはMobの場合は1で他は0？
+ * class change
  *------------------------------------------
  */
 void clif_class_change(struct block_list *bl,int class_,int type)
@@ -1520,1185 +1971,144 @@ void clif_class_change(struct block_list *bl,int class_,int type)
 }
 
 /*==========================================
- * MOB表示1
+ * MOB spawn standing
  *------------------------------------------
  */
 static int clif_mob0078(struct mob_data *md,unsigned char *buf)
 {
-	int len;
+	struct clif_spawn_info info;
 
 	nullpo_retr(0, md);
 
+	memset(&info, 0, sizeof(info));
+	info.flags = CLIF_SPAWN_F_MEMSET;
+	info.id = md->bl.id;
+	info.speed = status_get_speed(&md->bl);
+	info.opt1 = md->sc.opt1;
+	info.opt2 = md->sc.opt2;
+	info.option = md->sc.option;
+	info.opt3 = md->sc.opt3;
+	info.view_class = mob_get_viewclass(md->class_);
+	info.x = md->bl.x;
+	info.y = md->bl.y;
+	info.dir = (unsigned char)md->dir;
+	info.level = status_get_lv(&md->bl);
+	info.level_class = mob_get_viewclass(md->class_);
+	info.name = md->name;
+	info.class_id = md->class_;
+	clif_spawn_set_guild(&info, md->guild_id);
+
 	if(mob_is_pcview(md->class_)) {
+		info.packet_style = CLIF_SPAWN_STYLE_PC;
+		info.hair = mob_get_hair(md->class_);
+		info.weapon = mob_get_weapon(md->class_);
+		info.shield = mob_get_shield(md->class_);
+		info.head_bottom = mob_get_head_bottom(md->class_);
+		info.head_top = mob_get_head_top(md->class_);
+		info.head_mid = mob_get_head_mid(md->class_);
+		info.hair_color = mob_get_hair_color(md->class_);
+		info.clothes_color = mob_get_clothes_color(md->class_);
+		info.robe = mob_get_robe(md->class_);
+		info.karma = 1;
+		info.sex = mob_get_sex(md->class_);
+		info.xsize = 5;
+		info.ysize = 5;
 #if PACKETVER < 4
-		len = packet_db[0x78].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x78;
-		WBUFL(buf,2)=md->bl.id;
-		WBUFW(buf,6)=status_get_speed(&md->bl);
-		WBUFW(buf,8)=md->sc.opt1;
-		WBUFW(buf,10)=md->sc.opt2;
-		WBUFW(buf,12)=md->sc.option;
-		WBUFW(buf,14)=mob_get_viewclass(md->class_);
-		WBUFW(buf,16)=mob_get_hair(md->class_);
-		WBUFW(buf,18)=mob_get_weapon(md->class_);
-		WBUFW(buf,20)=mob_get_head_bottom(md->class_);
-		WBUFW(buf,22)=mob_get_shield(md->class_);
-		WBUFW(buf,24)=mob_get_head_top(md->class_);
-		WBUFW(buf,26)=mob_get_head_mid(md->class_);
-		WBUFW(buf,28)=mob_get_hair_color(md->class_);
-		WBUFW(buf,30)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFL(buf,38)=g->emblem_id;
-			WBUFL(buf,34)=md->guild_id;
-		}
-		WBUFW(buf,42)=md->sc.opt3;
-		WBUFB(buf,44)=1;
-		WBUFB(buf,45)=mob_get_sex(md->class_);
-		WBUFPOS(buf,46,md->bl.x,md->bl.y,md->dir);
-		WBUFB(buf,49)=5;
-		WBUFB(buf,50)=5;
-		WBUFLV(buf,52,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
+		info.manner = md->sc.opt3; /* written at manner slot */
+		info.opt3 = 0;
+		info.flags |= CLIF_SPAWN_F_EMBLEM_LONG;
 #elif PACKETVER < 7
-		len = packet_db[0x1d8].len;
-		memset(buf,0,packet_db[0x1d8].len);
-
-		WBUFW(buf,0)=0x1d8;
-		WBUFL(buf,2)=md->bl.id;
-		WBUFW(buf,6)=status_get_speed(&md->bl);
-		WBUFW(buf,8)=md->sc.opt1;
-		WBUFW(buf,10)=md->sc.opt2;
-		WBUFW(buf,12)=md->sc.option;
-		WBUFW(buf,14)=mob_get_viewclass(md->class_);
-		WBUFW(buf,16)=mob_get_hair(md->class_);
-		WBUFW(buf,18)=mob_get_weapon(md->class_);
-		WBUFW(buf,20)=mob_get_shield(md->class_);
-		WBUFW(buf,22)=mob_get_head_bottom(md->class_);
-		WBUFW(buf,24)=mob_get_head_top(md->class_);
-		WBUFW(buf,26)=mob_get_head_mid(md->class_);
-		WBUFW(buf,28)=mob_get_hair_color(md->class_);
-		WBUFW(buf,30)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFL(buf,38)=g->emblem_id;
-			WBUFL(buf,34)=md->guild_id;
-		}
-		WBUFW(buf,42)=md->sc.opt3;
-		WBUFB(buf,44)=1;
-		WBUFB(buf,45)=mob_get_sex(md->class_);
-		WBUFPOS(buf,46,md->bl.x,md->bl.y,md->dir);
-		WBUFB(buf,49)=5;
-		WBUFB(buf,50)=5;
-		WBUFLV(buf,52,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-#elif PACKETVER < 20080102
-		len = packet_db[0x22a].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x22a;
-		WBUFL(buf,2)=md->bl.id;
-		WBUFW(buf,6)=status_get_speed(&md->bl);
-		WBUFW(buf,8)=md->sc.opt1;
-		WBUFW(buf,10)=md->sc.opt2;
-		WBUFL(buf,12)=md->sc.option;
-		WBUFW(buf,16)=mob_get_viewclass(md->class_);
-		WBUFW(buf,18)=mob_get_hair(md->class_);
-		WBUFW(buf,20)=mob_get_weapon(md->class_);
-		WBUFW(buf,22)=mob_get_shield(md->class_);
-		WBUFW(buf,24)=mob_get_head_bottom(md->class_);
-		WBUFW(buf,26)=mob_get_head_top(md->class_);
-		WBUFW(buf,28)=mob_get_head_mid(md->class_);
-		WBUFW(buf,30)=mob_get_hair_color(md->class_);
-		WBUFW(buf,32)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,40)=g->emblem_id;
-			WBUFL(buf,36)=md->guild_id;
-		}
-		WBUFL(buf,44)=md->sc.opt3;
-		WBUFB(buf,48)=1;
-		WBUFB(buf,49)=mob_get_sex(md->class_);
-		WBUFPOS(buf,50,md->bl.x,md->bl.y,md->dir);
-		WBUFB(buf,53)=5;
-		WBUFB(buf,54)=5;
-		WBUFLV(buf,56,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-#elif PACKETVER < 20091104
-		len = packet_db[0x2ee].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x2ee;
-		WBUFL(buf,2)=md->bl.id;
-		WBUFW(buf,6)=status_get_speed(&md->bl);
-		WBUFW(buf,8)=md->sc.opt1;
-		WBUFW(buf,10)=md->sc.opt2;
-		WBUFL(buf,12)=md->sc.option;
-		WBUFW(buf,16)=mob_get_viewclass(md->class_);
-		WBUFW(buf,18)=mob_get_hair(md->class_);
-		WBUFW(buf,20)=mob_get_weapon(md->class_);
-		WBUFW(buf,22)=mob_get_shield(md->class_);
-		WBUFW(buf,24)=mob_get_head_bottom(md->class_);
-		WBUFW(buf,26)=mob_get_head_top(md->class_);
-		WBUFW(buf,28)=mob_get_head_mid(md->class_);
-		WBUFW(buf,30)=mob_get_hair_color(md->class_);
-		WBUFW(buf,32)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,40)=g->emblem_id;
-			WBUFL(buf,36)=md->guild_id;
-		}
-		WBUFL(buf,44)=md->sc.opt3;
-		WBUFB(buf,48)=1;
-		WBUFB(buf,49)=mob_get_sex(md->class_);
-		WBUFPOS(buf,50,md->bl.x,md->bl.y,md->dir);
-		WBUFB(buf,53)=5;
-		WBUFB(buf,54)=5;
-		WBUFLV(buf,56,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		WBUFW(buf,58)=0;
-#elif PACKETVER < 20110111
-		len = 63 + (int)strlen(md->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x7f9;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFW(buf,9)=status_get_speed(&md->bl);
-		WBUFW(buf,11)=md->sc.opt1;
-		WBUFW(buf,13)=md->sc.opt2;
-		WBUFL(buf,15)=md->sc.option;
-		WBUFW(buf,19)=mob_get_viewclass(md->class_);
-		WBUFW(buf,21)=mob_get_hair(md->class_);
-		WBUFW(buf,23)=mob_get_weapon(md->class_);
-		WBUFW(buf,25)=mob_get_shield(md->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(md->class_);
-		WBUFW(buf,29)=mob_get_head_top(md->class_);
-		WBUFW(buf,31)=mob_get_head_mid(md->class_);
-		WBUFW(buf,33)=mob_get_hair_color(md->class_);
-		WBUFW(buf,35)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,43)=g->emblem_id;
-			WBUFL(buf,39)=md->guild_id;
-		}
-		WBUFL(buf,47)=md->sc.opt3;
-		WBUFB(buf,51)=1;
-		WBUFB(buf,52)=mob_get_sex(md->class_);
-		WBUFPOS(buf,53,md->bl.x,md->bl.y,md->dir);
-		WBUFB(buf,56)=5;
-		WBUFB(buf,57)=5;
-		WBUFLV(buf,59,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		strncpy(WBUFP(buf,63),md->name,24);
-#elif PACKETVER < 20120328
-		len = 65 + (int)strlen(md->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x857;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFW(buf,9)=status_get_speed(&md->bl);
-		WBUFW(buf,11)=md->sc.opt1;
-		WBUFW(buf,13)=md->sc.opt2;
-		WBUFL(buf,15)=md->sc.option;
-		WBUFW(buf,19)=mob_get_viewclass(md->class_);
-		WBUFW(buf,21)=mob_get_hair(md->class_);
-		WBUFW(buf,23)=mob_get_weapon(md->class_);
-		WBUFW(buf,25)=mob_get_shield(md->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(md->class_);
-		WBUFW(buf,29)=mob_get_head_top(md->class_);
-		WBUFW(buf,31)=mob_get_head_mid(md->class_);
-		WBUFW(buf,33)=mob_get_hair_color(md->class_);
-		WBUFW(buf,35)=mob_get_clothes_color(md->class_);
-		WBUFW(buf,39)=mob_get_robe(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,45)=g->emblem_id;
-			WBUFL(buf,41)=md->guild_id;
-		}
-		WBUFL(buf,49)=md->sc.opt3;
-		WBUFB(buf,53)=1;
-		WBUFB(buf,54)=mob_get_sex(md->class_);
-		WBUFPOS(buf,55,md->bl.x,md->bl.y,md->dir);
-		WBUFB(buf,58)=5;
-		WBUFB(buf,59)=5;
-		WBUFLV(buf,61,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		strncpy(WBUFP(buf,65),md->name,24);
-#elif PACKETVER < 20131223
-		len = 74;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x915;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFW(buf,9)=status_get_speed(&md->bl);
-		WBUFW(buf,11)=md->sc.opt1;
-		WBUFW(buf,13)=md->sc.opt2;
-		WBUFL(buf,15)=md->sc.option;
-		WBUFW(buf,19)=mob_get_viewclass(md->class_);
-		WBUFW(buf,21)=mob_get_hair(md->class_);
-		WBUFW(buf,23)=mob_get_weapon(md->class_);
-		WBUFW(buf,25)=mob_get_shield(md->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(md->class_);
-		WBUFW(buf,29)=mob_get_head_top(md->class_);
-		WBUFW(buf,31)=mob_get_head_mid(md->class_);
-		WBUFW(buf,33)=mob_get_hair_color(md->class_);
-		WBUFW(buf,35)=mob_get_clothes_color(md->class_);
-		WBUFW(buf,39)=mob_get_robe(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,45)=g->emblem_id;
-			WBUFL(buf,41)=md->guild_id;
-		}
-		WBUFL(buf,49)=md->sc.opt3;
-		WBUFB(buf,53)=1;
-		WBUFB(buf,54)=mob_get_sex(md->class_);
-		WBUFPOS(buf,55,md->bl.x,md->bl.y,md->dir);
-		WBUFB(buf,58)=5;
-		WBUFB(buf,59)=5;
-		WBUFLV(buf,61,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		WBUFL(buf,65) = 0xffffffff;
-		WBUFL(buf,69) = 0xffffffff;
-		WBUFB(buf,73) = 0;
-#elif PACKETVER < 20150513
-		len = 78 + (int)strlen(md->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9dd;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=status_get_speed(&md->bl);
-		WBUFW(buf,15)=md->sc.opt1;
-		WBUFW(buf,17)=md->sc.opt2;
-		WBUFL(buf,19)=md->sc.option;
-		WBUFW(buf,23)=mob_get_viewclass(md->class_);
-		WBUFW(buf,25)=mob_get_hair(md->class_);
-		WBUFW(buf,27)=mob_get_weapon(md->class_);
-		WBUFW(buf,29)=mob_get_shield(md->class_);
-		WBUFW(buf,31)=mob_get_head_bottom(md->class_);
-		WBUFW(buf,33)=mob_get_head_top(md->class_);
-		WBUFW(buf,35)=mob_get_head_mid(md->class_);
-		WBUFW(buf,37)=mob_get_hair_color(md->class_);
-		WBUFW(buf,39)=mob_get_clothes_color(md->class_);
-		WBUFW(buf,43)=mob_get_robe(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,49)=g->emblem_id;
-			WBUFL(buf,45)=md->guild_id;
-		}
-		WBUFL(buf,53)=md->sc.opt3;
-		WBUFB(buf,57)=1;
-		WBUFB(buf,58)=mob_get_sex(md->class_);
-		WBUFPOS(buf,59,md->bl.x,md->bl.y,md->dir);
-		WBUFB(buf,62)=5;
-		WBUFB(buf,63)=5;
-		WBUFLV(buf,65,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		WBUFL(buf,69) = 0xffffffff;
-		WBUFL(buf,73) = 0xffffffff;
-		WBUFB(buf,77) = 0;
-#elif PACKETVER < 20180704
-		len = 80 + (int)strlen(md->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9ff;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=status_get_speed(&md->bl);
-		WBUFW(buf,15)=md->sc.opt1;
-		WBUFW(buf,17)=md->sc.opt2;
-		WBUFL(buf,19)=md->sc.option;
-		WBUFW(buf,23)=mob_get_viewclass(md->class_);
-		WBUFW(buf,25)=mob_get_hair(md->class_);
-		WBUFW(buf,27)=mob_get_weapon(md->class_);
-		WBUFW(buf,29)=mob_get_shield(md->class_);
-		WBUFW(buf,31)=mob_get_head_bottom(md->class_);
-		WBUFW(buf,33)=mob_get_head_top(md->class_);
-		WBUFW(buf,35)=mob_get_head_mid(md->class_);
-		WBUFW(buf,37)=mob_get_hair_color(md->class_);
-		WBUFW(buf,39)=mob_get_clothes_color(md->class_);
-		WBUFW(buf,43)=mob_get_robe(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,49)=g->emblem_id;
-			WBUFL(buf,45)=md->guild_id;
-		}
-		WBUFL(buf,53)=md->sc.opt3;
-		WBUFB(buf,57)=1;
-		WBUFB(buf,58)=mob_get_sex(md->class_);
-		WBUFPOS(buf,59,md->bl.x,md->bl.y,md->dir);
-		WBUFB(buf,62)=5;
-		WBUFB(buf,63)=5;
-		WBUFLV(buf,65,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		WBUFL(buf,69) = 0xffffffff;
-		WBUFL(buf,73) = 0xffffffff;
-		WBUFB(buf,77) = 0;
-		WBUFW(buf,78) = 0;
-#else
-		len = 84 + (int)strlen(md->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9ff;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=status_get_speed(&md->bl);
-		WBUFW(buf,15)=md->sc.opt1;
-		WBUFW(buf,17)=md->sc.opt2;
-		WBUFL(buf,19)=md->sc.option;
-		WBUFW(buf,23)=mob_get_viewclass(md->class_);
-		WBUFW(buf,25)=mob_get_hair(md->class_);
-		WBUFL(buf,27)=mob_get_weapon(md->class_);
-		WBUFL(buf,31)=mob_get_shield(md->class_);
-		WBUFW(buf,35)=mob_get_head_bottom(md->class_);
-		WBUFW(buf,37)=mob_get_head_top(md->class_);
-		WBUFW(buf,39)=mob_get_head_mid(md->class_);
-		WBUFW(buf,41)=mob_get_hair_color(md->class_);
-		WBUFW(buf,43)=mob_get_clothes_color(md->class_);
-		WBUFW(buf,47)=mob_get_robe(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,53)=g->emblem_id;
-			WBUFL(buf,49)=md->guild_id;
-		}
-		WBUFL(buf,57)=md->sc.opt3;
-		WBUFB(buf,61)=1;
-		WBUFB(buf,62)=mob_get_sex(md->class_);
-		WBUFPOS(buf,63,md->bl.x,md->bl.y,md->dir);
-		WBUFB(buf,66)=5;
-		WBUFB(buf,67)=5;
-		WBUFLV(buf,69,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		WBUFL(buf,73) = 0xffffffff;
-		WBUFL(buf,77) = 0xffffffff;
-		WBUFB(buf,81) = 0;
-		WBUFW(buf,82) = 0;
+		info.manner = 0;
+		info.opt3 = md->sc.opt3;
+		info.flags |= CLIF_SPAWN_F_EMBLEM_LONG;
 #endif
-		return len;
-	}
-#if PACKETVER < 20071106
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x78;
-	WBUFL(buf,2)=md->bl.id;
-	WBUFW(buf,6)=status_get_speed(&md->bl);
-	WBUFW(buf,8)=md->sc.opt1;
-	WBUFW(buf,10)=md->sc.opt2;
-	WBUFW(buf,12)=md->sc.option;
-	WBUFW(buf,14)=mob_get_viewclass(md->class_);
-	if((md->class_ == 1285 || md->class_ == 1286 || md->class_ == 1287) && md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFL(buf,22)=g->emblem_id;
-		WBUFL(buf,26)=md->guild_id;
-	}
-	WBUFW(buf,42)=md->sc.opt3;
-	WBUFPOS(buf,46,md->bl.x,md->bl.y,md->dir);
-	WBUFB(buf,49)=5;
-	WBUFB(buf,50)=5;
-	WBUFLV(buf,52,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-#elif PACKETVER < 20091104
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x78;
-	WBUFB(buf,2)=0;
-	WBUFL(buf,3)=md->bl.id;
-	WBUFW(buf,7)=status_get_speed(&md->bl);
-	WBUFW(buf,9)=md->sc.opt1;
-	WBUFW(buf,11)=md->sc.opt2;
-	WBUFW(buf,13)=md->sc.option;
-	WBUFW(buf,15)=mob_get_viewclass(md->class_);
-	if((md->class_ == 1285 || md->class_ == 1286 || md->class_ == 1287) && md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFL(buf,23)=g->emblem_id;
-		WBUFL(buf,27)=md->guild_id;
-	}
-	WBUFW(buf,43)=md->sc.opt3;
-	WBUFPOS(buf,47,md->bl.x,md->bl.y,md->dir);
-	WBUFB(buf,50)=5;
-	WBUFB(buf,51)=5;
-	WBUFLV(buf,52,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-#elif PACKETVER < 20110111
-	len = 63 + (int)strlen(md->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x7f9;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFW(buf,9)=status_get_speed(&md->bl);
-	WBUFW(buf,11)=md->sc.opt1;
-	WBUFW(buf,13)=md->sc.opt2;
-	WBUFL(buf,15)=md->sc.option;
-	WBUFW(buf,19)=mob_get_viewclass(md->class_);
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,43)=g->emblem_id;
-		WBUFL(buf,39)=md->guild_id;
-	}
-	WBUFL(buf,47)=md->sc.opt3;
-	WBUFPOS(buf,53,md->bl.x,md->bl.y,md->dir);
-	WBUFLV(buf,59,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	strncpy(WBUFP(buf,63),md->name,24);
-#elif PACKETVER < 20120328
-	len = 65 + (int)strlen(md->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x857;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFW(buf,9)=status_get_speed(&md->bl);
-	WBUFW(buf,11)=md->sc.opt1;
-	WBUFW(buf,13)=md->sc.opt2;
-	WBUFL(buf,15)=md->sc.option;
-	WBUFW(buf,19)=mob_get_viewclass(md->class_);
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,45)=g->emblem_id;
-		WBUFL(buf,41)=md->guild_id;
-	}
-	WBUFL(buf,49)=md->sc.opt3;
-	WBUFPOS(buf,55,md->bl.x,md->bl.y,md->dir);
-	WBUFLV(buf,61,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	strncpy(WBUFP(buf,65),md->name,24);
-#elif PACKETVER < 20131223
-	len = 74;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x915;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFW(buf,9)=status_get_speed(&md->bl);
-	WBUFW(buf,11)=md->sc.opt1;
-	WBUFW(buf,13)=md->sc.opt2;
-	WBUFL(buf,15)=md->sc.option;
-	WBUFW(buf,19)=mob_get_viewclass(md->class_);
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,45)=g->emblem_id;
-		WBUFL(buf,41)=md->guild_id;
-	}
-	WBUFL(buf,49)=md->sc.opt3;
-	WBUFPOS(buf,55,md->bl.x,md->bl.y,md->dir);
-	WBUFLV(buf,61,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	WBUFL(buf,65) = 0xffffffff;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFB(buf,73) = 0;
-#elif PACKETVER < 20150513
-	len = 78 + (int)strlen(md->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9dd;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=status_get_speed(&md->bl);
-	WBUFW(buf,15)=md->sc.opt1;
-	WBUFW(buf,17)=md->sc.opt2;
-	WBUFL(buf,19)=md->sc.option;
-	WBUFW(buf,23)=mob_get_viewclass(md->class_);
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,49)=g->emblem_id;
-		WBUFL(buf,45)=md->guild_id;
-	}
-	WBUFL(buf,53)=md->sc.opt3;
-	WBUFPOS(buf,59,md->bl.x,md->bl.y,md->dir);
-	WBUFLV(buf,65,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	strncpy(WBUFP(buf,78),md->name,24);
-#elif PACKETVER < 20180704
-	len = 80 + (int)strlen(md->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9ff;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=status_get_speed(&md->bl);
-	WBUFW(buf,15)=md->sc.opt1;
-	WBUFW(buf,17)=md->sc.opt2;
-	WBUFL(buf,19)=md->sc.option;
-	WBUFW(buf,23)=mob_get_viewclass(md->class_);
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,49)=g->emblem_id;
-		WBUFL(buf,45)=md->guild_id;
-	}
-	WBUFL(buf,53)=md->sc.opt3;
-	WBUFPOS(buf,59,md->bl.x,md->bl.y,md->dir);
-	WBUFLV(buf,65,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	WBUFW(buf,78) = 0;
-	strncpy(WBUFP(buf,80),md->name,24);
-#else
-	len = 84 + (int)strlen(md->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9ff;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=status_get_speed(&md->bl);
-	WBUFW(buf,15)=md->sc.opt1;
-	WBUFW(buf,17)=md->sc.opt2;
-	WBUFL(buf,19)=md->sc.option;
-	WBUFW(buf,23)=mob_get_viewclass(md->class_);
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,53)=g->emblem_id;
-		WBUFL(buf,49)=md->guild_id;
-	}
-	WBUFL(buf,57)=md->sc.opt3;
-	WBUFPOS(buf,63,md->bl.x,md->bl.y,md->dir);
-	WBUFLV(buf,69,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFL(buf,77) = 0xffffffff;
-	WBUFB(buf,81) = 0;
-	WBUFW(buf,82) = 0;
-	strncpy(WBUFP(buf,84),md->name,24);
+		/* original: strncpy only for name-bearing packets before 0x915/0x9dd era */
+#if PACKETVER < 20131223
+		info.flags |= CLIF_SPAWN_F_WRITE_NAME;
 #endif
-	return len;
+		return clif_spawn_build78(&info, buf);
+	}
+
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.flags |= CLIF_SPAWN_F_EMP_GUILD | CLIF_SPAWN_F_WRITE_NAME;
+	info.objecttype = 5;
+#if PACKETVER < 20091104
+	info.xsize = 5;
+	info.ysize = 5;
+#endif
+	return clif_spawn_build78(&info, buf);
 }
 
 /*==========================================
- * MOB表示2
+ * MOB spawn walking
  *------------------------------------------
  */
 static int clif_mob007b(struct mob_data *md,unsigned char *buf)
 {
-	int len;
-	unsigned int tick = gettick();
+	struct clif_spawn_info info;
 
 	nullpo_retr(0, md);
 
+	memset(&info, 0, sizeof(info));
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME;
+	info.id = md->bl.id;
+	info.speed = status_get_speed(&md->bl);
+	info.opt1 = md->sc.opt1;
+	info.opt2 = md->sc.opt2;
+	info.option = md->sc.option;
+	info.opt3 = md->sc.opt3;
+	info.view_class = mob_get_viewclass(md->class_);
+	info.x = md->bl.x;
+	info.y = md->bl.y;
+	info.to_x = md->ud.to_x;
+	info.to_y = md->ud.to_y;
+	info.level = status_get_lv(&md->bl);
+	info.level_class = mob_get_viewclass(md->class_);
+	info.name = md->name;
+	info.class_id = md->class_;
+	info.style = mob_get_style(md->class_);
+	clif_spawn_set_guild(&info, md->guild_id);
+
 	if(mob_is_pcview(md->class_)) {
+		info.packet_style = CLIF_SPAWN_STYLE_PC;
+		info.hair = mob_get_hair(md->class_);
+		info.weapon = mob_get_weapon(md->class_);
+		info.shield = mob_get_shield(md->class_);
+		info.head_bottom = mob_get_head_bottom(md->class_);
+		info.head_top = mob_get_head_top(md->class_);
+		info.head_mid = mob_get_head_mid(md->class_);
+		info.hair_color = mob_get_hair_color(md->class_);
+		info.clothes_color = mob_get_clothes_color(md->class_);
+		info.robe = mob_get_robe(md->class_);
+		info.karma = 1;
+		info.sex = mob_get_sex(md->class_);
+#if PACKETVER < 7 || PACKETVER >= 20110111
+		info.xsize = 5;
+		info.ysize = 5;
+#else
+		info.xsize = 0;
+		info.ysize = 0;
+#endif
 #if PACKETVER < 4
-		len = packet_db[0x7b].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x7b;
-		WBUFL(buf,2)=md->bl.id;
-		WBUFW(buf,6)=status_get_speed(&md->bl);
-		WBUFW(buf,8)=md->sc.opt1;
-		WBUFW(buf,10)=md->sc.opt2;
-		WBUFW(buf,12)=md->sc.option;
-		WBUFW(buf,14)=mob_get_viewclass(md->class_);
-		WBUFW(buf,16)=mob_get_hair(md->class_);
-		WBUFW(buf,18)=mob_get_weapon(md->class_);
-		WBUFW(buf,20)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,22)=tick;
-		WBUFW(buf,26)=mob_get_shield(md->class_);
-		WBUFW(buf,28)=mob_get_head_top(md->class_);
-		WBUFW(buf,30)=mob_get_head_mid(md->class_);
-		WBUFW(buf,32)=mob_get_hair_color(md->class_);
-		WBUFW(buf,34)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFL(buf,42)=g->emblem_id;
-			WBUFL(buf,38)=md->guild_id;
-		}
-		WBUFW(buf,46)=md->sc.opt3;
-		WBUFB(buf,48)=1;
-		WBUFB(buf,49)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,50,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,56)=5;
-		WBUFB(buf,57)=5;
-		WBUFLV(buf,58,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
+		info.manner = md->sc.opt3;
+		info.opt3 = 0;
+		info.flags |= CLIF_SPAWN_F_EMBLEM_LONG;
 #elif PACKETVER < 7
-		len = packet_db[0x1da].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x1da;
-		WBUFL(buf,2)=md->bl.id;
-		WBUFW(buf,6)=status_get_speed(&md->bl);
-		WBUFW(buf,8)=md->sc.opt1;
-		WBUFW(buf,10)=md->sc.opt2;
-		WBUFW(buf,12)=md->sc.option;
-		WBUFW(buf,14)=mob_get_viewclass(md->class_);
-		WBUFW(buf,16)=mob_get_hair(md->class_);
-		WBUFW(buf,18)=mob_get_weapon(md->class_);
-		WBUFW(buf,20)=mob_get_shield(md->class_);
-		WBUFW(buf,22)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,24)=tick;
-		WBUFW(buf,28)=mob_get_head_top(md->class_);
-		WBUFW(buf,30)=mob_get_head_mid(md->class_);
-		WBUFW(buf,32)=mob_get_hair_color(md->class_);
-		WBUFW(buf,34)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFL(buf,42)=g->emblem_id;
-			WBUFL(buf,38)=md->guild_id;
-		}
-		WBUFW(buf,46)=md->sc.opt3;
-		WBUFB(buf,48)=1;
-		WBUFB(buf,49)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,50,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,56)=5;
-		WBUFB(buf,57)=5;
-		WBUFLV(buf,58,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-#elif PACKETVER < 20071106
-		len = packet_db[0x22c].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x22c;
-		WBUFL(buf,2)=md->bl.id;
-		WBUFW(buf,6)=status_get_speed(&md->bl);
-		WBUFW(buf,8)=md->sc.opt1;
-		WBUFW(buf,10)=md->sc.opt2;
-		WBUFL(buf,12)=md->sc.option;
-		WBUFW(buf,16)=mob_get_viewclass(md->class_);
-		WBUFW(buf,18)=mob_get_hair(md->class_);
-		WBUFW(buf,20)=mob_get_weapon(md->class_);
-		WBUFW(buf,22)=mob_get_shield(md->class_);
-		WBUFW(buf,24)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,26)=tick;
-		WBUFW(buf,30)=mob_get_head_top(md->class_);
-		WBUFW(buf,32)=mob_get_head_mid(md->class_);
-		WBUFW(buf,34)=mob_get_hair_color(md->class_);
-		WBUFW(buf,36)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFL(buf,44)=g->emblem_id;
-			WBUFL(buf,40)=md->guild_id;
-		}
-		WBUFL(buf,48)=md->sc.opt3;
-		WBUFB(buf,52)=1;
-		WBUFB(buf,53)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,54,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,60)=0;
-		WBUFB(buf,61)=0;
-		WBUFLV(buf,62,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-#elif PACKETVER < 20080102
-		len = packet_db[0x22c].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x22c;
-		WBUFB(buf,2)=0;
-		WBUFL(buf,3)=md->bl.id;
-		WBUFW(buf,7)=status_get_speed(&md->bl);
-		WBUFW(buf,9)=md->sc.opt1;
-		WBUFW(buf,11)=md->sc.opt2;
-		WBUFL(buf,13)=md->sc.option;
-		WBUFW(buf,17)=mob_get_viewclass(md->class_);
-		WBUFW(buf,19)=mob_get_hair(md->class_);
-		WBUFW(buf,21)=mob_get_weapon(md->class_);
-		WBUFW(buf,23)=mob_get_shield(md->class_);
-		WBUFW(buf,25)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,27)=tick;
-		WBUFW(buf,31)=mob_get_head_top(md->class_);
-		WBUFW(buf,33)=mob_get_head_mid(md->class_);
-		WBUFW(buf,35)=mob_get_hair_color(md->class_);
-		WBUFW(buf,37)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFL(buf,45)=g->emblem_id;
-			WBUFL(buf,41)=md->guild_id;
-		}
-		WBUFL(buf,49)=md->sc.opt3;
-		WBUFB(buf,53)=1;
-		WBUFB(buf,54)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,55,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,61)=0;
-		WBUFB(buf,62)=0;
-		WBUFLV(buf,63,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-#elif PACKETVER < 20091104
-		len = packet_db[0x2ec].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x2ec;
-		WBUFB(buf,2)=0;
-		WBUFL(buf,3)=md->bl.id;
-		WBUFW(buf,7)=status_get_speed(&md->bl);
-		WBUFW(buf,9)=md->sc.opt1;
-		WBUFW(buf,11)=md->sc.opt2;
-		WBUFL(buf,13)=md->sc.option;
-		WBUFW(buf,17)=mob_get_viewclass(md->class_);
-		WBUFW(buf,19)=mob_get_hair(md->class_);
-		WBUFW(buf,21)=mob_get_weapon(md->class_);
-		WBUFW(buf,23)=mob_get_shield(md->class_);
-		WBUFW(buf,25)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,27)=tick;
-		WBUFW(buf,31)=mob_get_head_top(md->class_);
-		WBUFW(buf,33)=mob_get_head_mid(md->class_);
-		WBUFW(buf,35)=mob_get_hair_color(md->class_);
-		WBUFW(buf,37)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFL(buf,45)=g->emblem_id;
-			WBUFL(buf,41)=md->guild_id;
-		}
-		WBUFL(buf,49)=md->sc.opt3;
-		WBUFB(buf,53)=1;
-		WBUFB(buf,54)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,55,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,61)=0;
-		WBUFB(buf,62)=0;
-		WBUFLV(buf,63,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		WBUFW(buf,65)=0;
-#elif PACKETVER < 20110111
-		len = 69 + (int)strlen(md->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x7f7;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFW(buf,9)=status_get_speed(&md->bl);
-		WBUFW(buf,11)=md->sc.opt1;
-		WBUFW(buf,13)=md->sc.opt2;
-		WBUFL(buf,15)=md->sc.option;
-		WBUFW(buf,19)=mob_get_viewclass(md->class_);
-		WBUFW(buf,21)=mob_get_hair(md->class_);
-		WBUFW(buf,23)=mob_get_weapon(md->class_);
-		WBUFW(buf,25)=mob_get_shield(md->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,29)=tick;
-		WBUFW(buf,33)=mob_get_head_top(md->class_);
-		WBUFW(buf,35)=mob_get_head_mid(md->class_);
-		WBUFW(buf,37)=mob_get_hair_color(md->class_);
-		WBUFW(buf,39)=mob_get_clothes_color(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,47)=g->emblem_id;
-			WBUFL(buf,43)=md->guild_id;
-		}
-		WBUFL(buf,51)=md->sc.opt3;
-		WBUFB(buf,55)=1;
-		WBUFB(buf,56)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,57,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,63)=5;
-		WBUFB(buf,64)=5;
-		WBUFLV(buf,65,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		strncpy(WBUFP(buf,69),md->name,24);
-#elif PACKETVER < 20120328
-		len = 71 + (int)strlen(md->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x856;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFW(buf,9)=status_get_speed(&md->bl);
-		WBUFW(buf,11)=md->sc.opt1;
-		WBUFW(buf,13)=md->sc.opt2;
-		WBUFL(buf,15)=md->sc.option;
-		WBUFW(buf,19)=mob_get_viewclass(md->class_);
-		WBUFW(buf,21)=mob_get_hair(md->class_);
-		WBUFW(buf,23)=mob_get_weapon(md->class_);
-		WBUFW(buf,25)=mob_get_shield(md->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,29)=tick;
-		WBUFW(buf,33)=mob_get_head_top(md->class_);
-		WBUFW(buf,35)=mob_get_head_mid(md->class_);
-		WBUFW(buf,37)=mob_get_hair_color(md->class_);
-		WBUFW(buf,39)=mob_get_clothes_color(md->class_);
-		WBUFW(buf,43)=mob_get_robe(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,49)=g->emblem_id;
-			WBUFL(buf,45)=md->guild_id;
-		}
-		WBUFL(buf,53)=md->sc.opt3;
-		WBUFB(buf,57)=1;
-		WBUFB(buf,58)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,59,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,65)=5;
-		WBUFB(buf,66)=5;
-		WBUFLV(buf,67,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		strncpy(WBUFP(buf,71),md->name,24);
-#elif PACKETVER < 20131223
-		len = 80;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x914;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFW(buf,9)=status_get_speed(&md->bl);
-		WBUFW(buf,11)=md->sc.opt1;
-		WBUFW(buf,13)=md->sc.opt2;
-		WBUFL(buf,15)=md->sc.option;
-		WBUFW(buf,19)=mob_get_viewclass(md->class_);
-		WBUFW(buf,21)=mob_get_hair(md->class_);
-		WBUFW(buf,23)=mob_get_weapon(md->class_);
-		WBUFW(buf,25)=mob_get_shield(md->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,29)=tick;
-		WBUFW(buf,33)=mob_get_head_top(md->class_);
-		WBUFW(buf,35)=mob_get_head_mid(md->class_);
-		WBUFW(buf,37)=mob_get_hair_color(md->class_);
-		WBUFW(buf,39)=mob_get_clothes_color(md->class_);
-		WBUFW(buf,43)=mob_get_robe(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,49)=g->emblem_id;
-			WBUFL(buf,45)=md->guild_id;
-		}
-		WBUFL(buf,53)=md->sc.opt3;
-		WBUFB(buf,57)=1;
-		WBUFB(buf,58)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,59,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,65)=5;
-		WBUFB(buf,66)=5;
-		WBUFLV(buf,67,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		WBUFL(buf,71) = 0xffffffff;
-		WBUFL(buf,75) = 0xffffffff;
-		WBUFB(buf,79) = 0;
-#elif PACKETVER < 20150513
-		len = 84 + (int)strlen(md->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9db;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=status_get_speed(&md->bl);
-		WBUFW(buf,15)=md->sc.opt1;
-		WBUFW(buf,17)=md->sc.opt2;
-		WBUFL(buf,19)=md->sc.option;
-		WBUFW(buf,23)=mob_get_viewclass(md->class_);
-		WBUFW(buf,25)=mob_get_hair(md->class_);
-		WBUFW(buf,27)=mob_get_weapon(md->class_);
-		WBUFW(buf,29)=mob_get_shield(md->class_);
-		WBUFW(buf,31)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,33)=tick;
-		WBUFW(buf,37)=mob_get_head_top(md->class_);
-		WBUFW(buf,39)=mob_get_head_mid(md->class_);
-		WBUFW(buf,41)=mob_get_hair_color(md->class_);
-		WBUFW(buf,43)=mob_get_clothes_color(md->class_);
-		WBUFW(buf,47)=mob_get_robe(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,53)=g->emblem_id;
-			WBUFL(buf,49)=md->guild_id;
-		}
-		WBUFL(buf,57)=md->sc.opt3;
-		WBUFB(buf,61)=1;
-		WBUFB(buf,62)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,63,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,69)=5;
-		WBUFB(buf,70)=5;
-		WBUFLV(buf,71,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		WBUFL(buf,75) = 0xffffffff;
-		WBUFL(buf,79) = 0xffffffff;
-		WBUFB(buf,83) = 0;
-		strncpy(WBUFP(buf,84),md->name,24);
-#elif PACKETVER < 20180704
-		len = 86 + (int)strlen(md->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9fd;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=status_get_speed(&md->bl);
-		WBUFW(buf,15)=md->sc.opt1;
-		WBUFW(buf,17)=md->sc.opt2;
-		WBUFL(buf,19)=md->sc.option;
-		WBUFW(buf,23)=mob_get_viewclass(md->class_);
-		WBUFW(buf,25)=mob_get_hair(md->class_);
-		WBUFW(buf,27)=mob_get_weapon(md->class_);
-		WBUFW(buf,29)=mob_get_shield(md->class_);
-		WBUFW(buf,31)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,33)=tick;
-		WBUFW(buf,37)=mob_get_head_top(md->class_);
-		WBUFW(buf,39)=mob_get_head_mid(md->class_);
-		WBUFW(buf,41)=mob_get_hair_color(md->class_);
-		WBUFW(buf,43)=mob_get_clothes_color(md->class_);
-		WBUFW(buf,47)=mob_get_robe(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,53)=g->emblem_id;
-			WBUFL(buf,49)=md->guild_id;
-		}
-		WBUFL(buf,57)=md->sc.opt3;
-		WBUFB(buf,61)=1;
-		WBUFB(buf,62)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,63,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,69)=5;
-		WBUFB(buf,70)=5;
-		WBUFLV(buf,71,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		WBUFL(buf,75) = 0xffffffff;
-		WBUFL(buf,79) = 0xffffffff;
-		WBUFB(buf,83) = 0;
-		WBUFW(buf,84) = mob_get_style(md->class_);
-		strncpy(WBUFP(buf,86),md->name,24);
-#else
-		len = 90 + (int)strlen(md->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9fd;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=md->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=status_get_speed(&md->bl);
-		WBUFW(buf,15)=md->sc.opt1;
-		WBUFW(buf,17)=md->sc.opt2;
-		WBUFL(buf,19)=md->sc.option;
-		WBUFW(buf,23)=mob_get_viewclass(md->class_);
-		WBUFW(buf,25)=mob_get_hair(md->class_);
-		WBUFL(buf,27)=mob_get_weapon(md->class_);
-		WBUFL(buf,31)=mob_get_shield(md->class_);
-		WBUFW(buf,35)=mob_get_head_bottom(md->class_);
-		WBUFL(buf,37)=tick;
-		WBUFW(buf,41)=mob_get_head_top(md->class_);
-		WBUFW(buf,43)=mob_get_head_mid(md->class_);
-		WBUFW(buf,45)=mob_get_hair_color(md->class_);
-		WBUFW(buf,47)=mob_get_clothes_color(md->class_);
-		WBUFW(buf,49)=mob_get_robe(md->class_);
-		if(md->guild_id){
-			struct guild *g=guild_search(md->guild_id);
-			if(g)
-				WBUFW(buf,57)=g->emblem_id;
-			WBUFL(buf,53)=md->guild_id;
-		}
-		WBUFL(buf,61)=md->sc.opt3;
-		WBUFB(buf,65)=1;
-		WBUFB(buf,66)=mob_get_sex(md->class_);
-		WBUFPOS2(buf,67,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-		WBUFB(buf,73)=5;
-		WBUFB(buf,74)=5;
-		WBUFLV(buf,75,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-		WBUFL(buf,79) = 0xffffffff;
-		WBUFL(buf,83) = 0xffffffff;
-		WBUFB(buf,87) = 0;
-		WBUFW(buf,88) = mob_get_style(md->class_);
-		strncpy(WBUFP(buf,90),md->name,24);
+		info.manner = 0;
+		info.opt3 = md->sc.opt3;
+		info.flags |= CLIF_SPAWN_F_EMBLEM_LONG;
 #endif
-		return len;
+		return clif_spawn_build7b(&info, buf);
 	}
 
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.flags |= CLIF_SPAWN_F_EMP_GUILD;
+	info.objecttype = 5;
 #if PACKETVER < 20091104
-	len = packet_db[0x7b].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x7b;
-	WBUFL(buf,2)=md->bl.id;
-	WBUFW(buf,6)=status_get_speed(&md->bl);
-	WBUFW(buf,8)=md->sc.opt1;
-	WBUFW(buf,10)=md->sc.opt2;
-	WBUFW(buf,12)=md->sc.option;
-	WBUFW(buf,14)=mob_get_viewclass(md->class_);
-	WBUFL(buf,22)=tick;
-	if((md->class_ == 1285 || md->class_ == 1286 || md->class_ == 1287) && md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFL(buf,26)=g->emblem_id;
-		WBUFL(buf,30)=md->guild_id;
-	}
-	WBUFW(buf,46)=md->sc.opt3;
-	WBUFPOS2(buf,50,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-	WBUFB(buf,56)=5;
-	WBUFB(buf,57)=5;
-	WBUFLV(buf,58,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-#elif PACKETVER < 20110111
-	len = 69 + (int)strlen(md->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x7f7;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFW(buf,9)=status_get_speed(&md->bl);
-	WBUFW(buf,11)=md->sc.opt1;
-	WBUFW(buf,13)=md->sc.opt2;
-	WBUFL(buf,15)=md->sc.option;
-	WBUFW(buf,19)=mob_get_viewclass(md->class_);
-	WBUFL(buf,29)=tick;
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,47)=g->emblem_id;
-		WBUFL(buf,43)=md->guild_id;
-	}
-	WBUFL(buf,51)=md->sc.opt3;
-	WBUFPOS2(buf,57,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-	WBUFLV(buf,65,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	strncpy(WBUFP(buf,69),md->name,24);
-#elif PACKETVER < 20120328
-	len = 71 + (int)strlen(md->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x856;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFW(buf,9)=status_get_speed(&md->bl);
-	WBUFW(buf,11)=md->sc.opt1;
-	WBUFW(buf,13)=md->sc.opt2;
-	WBUFL(buf,15)=md->sc.option;
-	WBUFW(buf,19)=mob_get_viewclass(md->class_);
-	WBUFL(buf,29)=tick;
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,49)=g->emblem_id;
-		WBUFL(buf,45)=md->guild_id;
-	}
-	WBUFL(buf,53)=md->sc.opt3;
-	WBUFPOS2(buf,59,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-	WBUFLV(buf,67,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	strncpy(WBUFP(buf,71),md->name,24);
-#elif PACKETVER < 20131223
-	len = 80;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x914;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFW(buf,9)=status_get_speed(&md->bl);
-	WBUFW(buf,11)=md->sc.opt1;
-	WBUFW(buf,13)=md->sc.opt2;
-	WBUFL(buf,15)=md->sc.option;
-	WBUFW(buf,19)=mob_get_viewclass(md->class_);
-	WBUFL(buf,29)=tick;
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,49)=g->emblem_id;
-		WBUFL(buf,45)=md->guild_id;
-	}
-	WBUFL(buf,53)=md->sc.opt3;
-	WBUFPOS2(buf,59,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-	WBUFLV(buf,67,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	WBUFL(buf,71) = 0xffffffff;
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFB(buf,79) = 0;
-#elif PACKETVER < 20150513
-	len = 84 + (int)strlen(md->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9db;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=status_get_speed(&md->bl);
-	WBUFW(buf,15)=md->sc.opt1;
-	WBUFW(buf,17)=md->sc.opt2;
-	WBUFL(buf,19)=md->sc.option;
-	WBUFW(buf,23)=mob_get_viewclass(md->class_);
-	WBUFL(buf,33)=tick;
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,53)=g->emblem_id;
-		WBUFL(buf,49)=md->guild_id;
-	}
-	WBUFL(buf,57)=md->sc.opt3;
-	WBUFPOS2(buf,63,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-	WBUFLV(buf,71,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	strncpy(WBUFP(buf,84),md->name,24);
-#elif PACKETVER < 20180704
-	len = 86 + (int)strlen(md->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9fd;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=status_get_speed(&md->bl);
-	WBUFW(buf,15)=md->sc.opt1;
-	WBUFW(buf,17)=md->sc.opt2;
-	WBUFL(buf,19)=md->sc.option;
-	WBUFW(buf,23)=mob_get_viewclass(md->class_);
-	WBUFL(buf,33)=tick;
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,53)=g->emblem_id;
-		WBUFL(buf,49)=md->guild_id;
-	}
-	WBUFL(buf,57)=md->sc.opt3;
-	WBUFPOS2(buf,63,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-	WBUFLV(buf,71,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	WBUFW(buf,84) = mob_get_style(md->class_);
-	strncpy(WBUFP(buf,86),md->name,24);
-#else
-	len = 90 + (int)strlen(md->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9fd;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=5;
-	WBUFL(buf,5)=md->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=status_get_speed(&md->bl);
-	WBUFW(buf,15)=md->sc.opt1;
-	WBUFW(buf,17)=md->sc.opt2;
-	WBUFL(buf,19)=md->sc.option;
-	WBUFW(buf,23)=mob_get_viewclass(md->class_);
-	WBUFL(buf,37)=tick;
-	if(md->guild_id){
-		struct guild *g=guild_search(md->guild_id);
-		if(g)
-			WBUFW(buf,57)=g->emblem_id;
-		WBUFL(buf,53)=md->guild_id;
-	}
-	WBUFL(buf,61)=md->sc.opt3;
-	WBUFPOS2(buf,67,md->bl.x,md->bl.y,md->ud.to_x,md->ud.to_y,8,8);
-	WBUFLV(buf,75,status_get_lv(&md->bl),mob_get_viewclass(md->class_));
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFL(buf,83) = 0xffffffff;
-	WBUFB(buf,87) = 0;
-	WBUFW(buf,88) = mob_get_style(md->class_);
-	strncpy(WBUFP(buf,90),md->name,24);
+	info.xsize = 5;
+	info.ysize = 5;
 #endif
-	return len;
+	return clif_spawn_build7b(&info, buf);
 }
 
 /*==========================================
@@ -2707,12 +2117,12 @@ static int clif_mob007b(struct mob_data *md,unsigned char *buf)
  */
 static int clif_npc0078(struct npc_data *nd,unsigned char *buf,struct map_session_data* sd)
 {
-	struct guild *g;
-	int len;
-	int option = nd->option;
+	struct clif_spawn_info info;
+	int option;
 
 	nullpo_retr(0, nd);
 
+	option = nd->option;
 	if(sd && option&OPTION_CLOAKING) {
 		int i;
 		for(i=0; i < MAX_CLOAKEDNPC; i++) {
@@ -2722,282 +2132,45 @@ static int clif_npc0078(struct npc_data *nd,unsigned char *buf,struct map_sessio
 			}
 		}
 	}
-#if PACKETVER < 20071106
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
 
-	WBUFW(buf,0)=0x78;
-	WBUFL(buf,2)=nd->bl.id;
-	WBUFW(buf,6)=nd->speed;
-	WBUFW(buf,12)=option;
-	WBUFW(buf,14)=nd->class_;
-	if( nd->subtype != WARP &&
-	    nd->class_ == WARP_DEBUG_CLASS &&
-	    nd->u.scr.guild_id > 0 &&
-	    (g = guild_search(nd->u.scr.guild_id)) )
-	{
-		WBUFL(buf,26)=g->guild_id;
-		WBUFL(buf,36)=g->guild_id;
-		WBUFW(buf,40)=g->emblem_id;
-	}
-	WBUFPOS(buf,46,nd->bl.x,nd->bl.y,nd->dir);
-	WBUFB(buf,49)=5;
-	WBUFB(buf,50)=5;
-#elif PACKETVER < 20091104
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x78;
-	WBUFB(buf,2)=0;
-	WBUFL(buf,3)=nd->bl.id;
-	WBUFW(buf,7)=nd->speed;
-	WBUFW(buf,13)=option;
-	WBUFW(buf,15)=nd->class_;
-	if( nd->subtype != WARP &&
-	    nd->class_ == WARP_DEBUG_CLASS &&
-	    nd->u.scr.guild_id > 0 &&
-	    (g = guild_search(nd->u.scr.guild_id)) )
-	{
-		WBUFL(buf,26)=g->guild_id;
-		WBUFL(buf,37)=g->guild_id;
-		WBUFW(buf,41)=g->emblem_id;
-	}
-	WBUFPOS(buf,47,nd->bl.x,nd->bl.y,nd->dir);
-	WBUFB(buf,50)=5;
-	WBUFB(buf,51)=5;
-#elif PACKETVER < 20110111
-	len = 63 + (int)strlen(nd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x7f9;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=(nd->u.scr.moveable > 0)? 12: 6;
-	WBUFL(buf,5)=nd->bl.id;
-	WBUFW(buf,9)=nd->speed;
-	WBUFL(buf,15)=option;
-	WBUFW(buf,19)=nd->class_;
-	if(npc_is_pcview(nd)) {
-		WBUFW(buf,21)=nd->hair;
-		WBUFW(buf,23)=0;
-		WBUFW(buf,25)=0;
-		WBUFW(buf,27)=nd->head_bottom;
-		WBUFW(buf,29)=nd->head_top;
-		WBUFW(buf,31)=nd->head_mid;
-		WBUFW(buf,33)=nd->hair_color;
-		WBUFW(buf,35)=nd->clothes_color;
-		WBUFW(buf,37)=0;
-		WBUFB(buf,52)=nd->sex;
-	}
-	if( nd->subtype != WARP &&
-	    nd->class_ == WARP_DEBUG_CLASS &&
-	    nd->u.scr.guild_id > 0 &&
-	    (g = guild_search(nd->u.scr.guild_id)) )
-	{
-		WBUFL(buf,31)=g->guild_id;
-		WBUFL(buf,39)=g->guild_id;
-		WBUFW(buf,43)=g->emblem_id;
-	}
-	WBUFPOS(buf,53,nd->bl.x,nd->bl.y,nd->dir);
-	WBUFW(buf,59)=1;
-	strncpy(WBUFP(buf,63),nd->name,24);
-#elif PACKETVER < 20120328
-	len = 65 + (int)strlen(nd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x857;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=(nd->u.scr.moveable > 0)? 12: 6;
-	WBUFL(buf,5)=nd->bl.id;
-	WBUFW(buf,9)=nd->speed;
-	WBUFL(buf,15)=option;
-	WBUFW(buf,19)=nd->class_;
-	if(npc_is_pcview(nd)) {
-		WBUFW(buf,21)=nd->hair;
-		WBUFW(buf,23)=0;
-		WBUFW(buf,25)=0;
-		WBUFW(buf,27)=nd->head_bottom;
-		WBUFW(buf,29)=nd->head_top;
-		WBUFW(buf,31)=nd->head_mid;
-		WBUFW(buf,33)=nd->hair_color;
-		WBUFW(buf,35)=nd->clothes_color;
-		WBUFW(buf,37)=0;
-		WBUFW(buf,39)=nd->robe;
-		WBUFB(buf,54)=nd->sex;
-	}
-	if( nd->subtype != WARP &&
-	    nd->class_ == WARP_DEBUG_CLASS &&
-	    nd->u.scr.guild_id > 0 &&
-	    (g = guild_search(nd->u.scr.guild_id)) )
-	{
-		WBUFL(buf,31)=g->guild_id;
-		WBUFL(buf,41)=g->guild_id;
-		WBUFW(buf,45)=g->emblem_id;
-	}
-	WBUFPOS(buf,55,nd->bl.x,nd->bl.y,nd->dir);
-	WBUFW(buf,61)=1;
-	strncpy(WBUFP(buf,65),nd->name,24);
-#elif PACKETVER < 20131223
-	len = 74;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x915;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=(nd->u.scr.moveable > 0)? 12: 6;
-	WBUFL(buf,5)=nd->bl.id;
-	WBUFW(buf,9)=nd->speed;
-	WBUFL(buf,15)=option;
-	WBUFW(buf,19)=nd->class_;
-	if(npc_is_pcview(nd)) {
-		WBUFW(buf,21)=nd->hair;
-		WBUFW(buf,23)=0;
-		WBUFW(buf,25)=0;
-		WBUFW(buf,27)=nd->head_bottom;
-		WBUFW(buf,29)=nd->head_top;
-		WBUFW(buf,31)=nd->head_mid;
-		WBUFW(buf,33)=nd->hair_color;
-		WBUFW(buf,35)=nd->clothes_color;
-		WBUFW(buf,37)=0;
-		WBUFW(buf,39)=nd->robe;
-		WBUFB(buf,54)=nd->sex;
-	}
-	if( nd->subtype != WARP &&
-	    nd->class_ == WARP_DEBUG_CLASS &&
-	    nd->u.scr.guild_id > 0 &&
-	    (g = guild_search(nd->u.scr.guild_id)) )
-	{
-		WBUFL(buf,31)=g->guild_id;
-		WBUFL(buf,41)=g->guild_id;
-		WBUFW(buf,45)=g->emblem_id;
-	}
-	WBUFPOS(buf,55,nd->bl.x,nd->bl.y,nd->dir);
-	WBUFW(buf,61)=1;
-	WBUFL(buf,65) = 0xffffffff;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFB(buf,73) = 0;
-#elif PACKETVER < 20150513
-	len = 78 + (int)strlen(nd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9dd;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=(nd->u.scr.moveable > 0)? 12: 6;
-	WBUFL(buf,5)=nd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=nd->speed;
-	WBUFL(buf,19)=option;
-	WBUFW(buf,23)=nd->class_;
-	if(npc_is_pcview(nd)) {
-		WBUFW(buf,25)=nd->hair;
-		WBUFW(buf,27)=0;
-		WBUFW(buf,29)=0;
-		WBUFW(buf,31)=nd->head_bottom;
-		WBUFW(buf,33)=nd->head_top;
-		WBUFW(buf,35)=nd->head_mid;
-		WBUFW(buf,37)=nd->hair_color;
-		WBUFW(buf,39)=nd->clothes_color;
-		WBUFW(buf,41)=0;
-		WBUFW(buf,43)=nd->robe;
-		WBUFB(buf,58)=nd->sex;
-	}
-	if( nd->subtype != WARP &&
-	    nd->class_ == WARP_DEBUG_CLASS &&
-	    nd->u.scr.guild_id > 0 &&
-	    (g = guild_search(nd->u.scr.guild_id)) )
-	{
-		WBUFL(buf,35)=g->guild_id;
-		WBUFL(buf,45)=g->guild_id;
-		WBUFW(buf,49)=g->emblem_id;
-	}
-	WBUFPOS(buf,59,nd->bl.x,nd->bl.y,nd->dir);
-	WBUFW(buf,65)=1;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	strncpy(WBUFP(buf,78),nd->name,24);
-#elif PACKETVER < 20180704
-	len = 80 + (int)strlen(nd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9ff;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=(nd->u.scr.moveable > 0)? 12: 6;
-	WBUFL(buf,5)=nd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=nd->speed;
-	WBUFL(buf,19)=option;
-	WBUFW(buf,23)=nd->class_;
-	if(npc_is_pcview(nd)) {
-		WBUFW(buf,25)=nd->hair;
-		WBUFW(buf,27)=0;
-		WBUFW(buf,29)=0;
-		WBUFW(buf,31)=nd->head_bottom;
-		WBUFW(buf,33)=nd->head_top;
-		WBUFW(buf,35)=nd->head_mid;
-		WBUFW(buf,37)=nd->hair_color;
-		WBUFW(buf,39)=nd->clothes_color;
-		WBUFW(buf,41)=0;
-		WBUFW(buf,43)=nd->robe;
-		WBUFB(buf,58)=nd->sex;
-		WBUFW(buf,78)=nd->style;
-	}
-	if( nd->subtype != WARP &&
-	    nd->class_ == WARP_DEBUG_CLASS &&
-	    nd->u.scr.guild_id > 0 &&
-	    (g = guild_search(nd->u.scr.guild_id)) )
-	{
-		WBUFL(buf,35)=g->guild_id;
-		WBUFL(buf,45)=g->guild_id;
-		WBUFW(buf,49)=g->emblem_id;
-	}
-	WBUFPOS(buf,59,nd->bl.x,nd->bl.y,nd->dir);
-	WBUFW(buf,65)=1;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	strncpy(WBUFP(buf,80),nd->name,24);
-#else
-	len = 84 + (int)strlen(nd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9ff;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=(nd->u.scr.moveable > 0)? 12: 6;
-	WBUFL(buf,5)=nd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=nd->speed;
-	WBUFL(buf,19)=option;
-	WBUFW(buf,23)=nd->class_;
-	if(npc_is_pcview(nd)) {
-		WBUFW(buf,25)=nd->hair;
-		WBUFL(buf,27)=0;
-		WBUFL(buf,31)=0;
-		WBUFW(buf,35)=nd->head_bottom;
-		WBUFW(buf,37)=nd->head_top;
-		WBUFW(buf,39)=nd->head_mid;
-		WBUFW(buf,41)=nd->hair_color;
-		WBUFW(buf,43)=nd->clothes_color;
-		WBUFW(buf,45)=0;
-		WBUFW(buf,47)=nd->robe;
-		WBUFB(buf,62)=nd->sex;
-		WBUFW(buf,82)=nd->style;
-	}
-	if( nd->subtype != WARP &&
-	    nd->class_ == WARP_DEBUG_CLASS &&
-	    nd->u.scr.guild_id > 0 &&
-	    (g = guild_search(nd->u.scr.guild_id)) )
-	{
-		WBUFL(buf,39)=g->guild_id;
-		WBUFL(buf,49)=g->guild_id;
-		WBUFW(buf,53)=g->emblem_id;
-	}
-	WBUFPOS(buf,63,nd->bl.x,nd->bl.y,nd->dir);
-	WBUFW(buf,69)=1;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFL(buf,77) = 0xffffffff;
-	WBUFB(buf,81) = 0;
-	strncpy(WBUFP(buf,84),nd->name,24);
+	memset(&info, 0, sizeof(info));
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME | CLIF_SPAWN_F_RAW_LEVEL;
+	info.id = nd->bl.id;
+	info.speed = nd->speed;
+	info.option = option;
+	info.view_class = nd->class_;
+	info.x = nd->bl.x;
+	info.y = nd->bl.y;
+	info.dir = (unsigned char)nd->dir;
+	info.level = 1;
+	info.name = nd->name;
+	info.objecttype = (nd->u.scr.moveable > 0) ? 12 : 6;
+#if PACKETVER < 20091104
+	info.xsize = 5;
+	info.ysize = 5;
 #endif
-	return len;
+	if(npc_is_pcview(nd)) {
+		info.flags |= CLIF_SPAWN_F_NPC_PCVIEW;
+		info.hair = nd->hair;
+		info.head_bottom = nd->head_bottom;
+		info.head_top = nd->head_top;
+		info.head_mid = nd->head_mid;
+		info.hair_color = nd->hair_color;
+		info.clothes_color = nd->clothes_color;
+		info.robe = nd->robe;
+		info.sex = nd->sex;
+		info.style = nd->style;
+	}
+	if( nd->subtype != WARP &&
+	    nd->class_ == WARP_DEBUG_CLASS &&
+	    nd->u.scr.guild_id > 0 &&
+	    guild_search(nd->u.scr.guild_id) )
+	{
+		info.flags |= CLIF_SPAWN_F_NPC_GUILD;
+		clif_spawn_set_guild(&info, nd->u.scr.guild_id);
+	}
+	return clif_spawn_build78(&info, buf);
 }
 
 /*==========================================
@@ -3006,12 +2179,12 @@ static int clif_npc0078(struct npc_data *nd,unsigned char *buf,struct map_sessio
  */
 static int clif_npc007b(struct npc_data *nd,unsigned char *buf,struct map_session_data* sd)
 {
-	int len;
-	unsigned int tick = gettick();
-	int option = nd->option;
+	struct clif_spawn_info info;
+	int option;
 
 	nullpo_retr(0, nd);
 
+	option = nd->option;
 	if(sd && option&OPTION_CLOAKING) {
 		int i;
 		for(i=0; i < MAX_CLOAKEDNPC; i++) {
@@ -3022,72 +2195,32 @@ static int clif_npc007b(struct npc_data *nd,unsigned char *buf,struct map_sessio
 		}
 	}
 
-#if PACKETVER < 20180704
-	len = 86 + (int)strlen(nd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9fd;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=(nd->u.scr.moveable > 0)? 12: 6;
-	WBUFL(buf,5)=nd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=nd->speed;
-	WBUFL(buf,19)=option;
-	WBUFW(buf,23)=nd->class_;
+	memset(&info, 0, sizeof(info));
+	info.packet_style = CLIF_SPAWN_STYLE_NPC_WALK;
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME;
+	info.id = nd->bl.id;
+	info.speed = nd->speed;
+	info.option = option;
+	info.view_class = nd->class_;
+	info.x = nd->bl.x;
+	info.y = nd->bl.y;
+	info.to_x = nd->ud.to_x;
+	info.to_y = nd->ud.to_y;
+	info.name = nd->name;
+	info.objecttype = (nd->u.scr.moveable > 0) ? 12 : 6;
 	if(npc_is_pcview(nd)) {
-		WBUFW(buf,25)=nd->hair;
-		WBUFL(buf,27)=0;
-		WBUFL(buf,29)=0;
-		WBUFW(buf,31)=nd->head_bottom;
-		WBUFW(buf,37)=nd->head_top;
-		WBUFW(buf,39)=nd->head_mid;
-		WBUFW(buf,41)=nd->hair_color;
-		WBUFW(buf,43)=nd->clothes_color;
-		WBUFW(buf,45)=0;
-		WBUFW(buf,47)=nd->robe;
-		WBUFB(buf,62)=nd->sex;
-		WBUFW(buf,84)=nd->style;
+		info.flags |= CLIF_SPAWN_F_NPC_PCVIEW;
+		info.hair = nd->hair;
+		info.head_bottom = nd->head_bottom;
+		info.head_top = nd->head_top;
+		info.head_mid = nd->head_mid;
+		info.hair_color = nd->hair_color;
+		info.clothes_color = nd->clothes_color;
+		info.robe = nd->robe;
+		info.sex = nd->sex;
+		info.style = nd->style;
 	}
-	WBUFL(buf,33)=tick;
-	WBUFPOS2(buf,63,nd->bl.x,nd->bl.y,nd->ud.to_x,nd->ud.to_y,8,8);
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	strncpy(WBUFP(buf,86),nd->name,24);
-#else
-	len = 90 + (int)strlen(nd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9fd;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=(nd->u.scr.moveable > 0)? 12: 6;
-	WBUFL(buf,5)=nd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=nd->speed;
-	WBUFL(buf,19)=option;
-	WBUFW(buf,23)=nd->class_;
-	if(npc_is_pcview(nd)) {
-		WBUFW(buf,25)=nd->hair;
-		WBUFL(buf,27)=0;
-		WBUFL(buf,31)=0;
-		WBUFW(buf,35)=nd->head_bottom;
-		WBUFW(buf,41)=nd->head_top;
-		WBUFW(buf,43)=nd->head_mid;
-		WBUFW(buf,45)=nd->hair_color;
-		WBUFW(buf,47)=nd->clothes_color;
-		WBUFW(buf,49)=0;
-		WBUFW(buf,51)=nd->robe;
-		WBUFB(buf,66)=nd->sex;
-		WBUFW(buf,88)=nd->style;
-	}
-	WBUFL(buf,37)=tick;
-	WBUFPOS2(buf,67,nd->bl.x,nd->bl.y,nd->ud.to_x,nd->ud.to_y,8,8);
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFL(buf,83) = 0xffffffff;
-	WBUFB(buf,87) = 0;
-	strncpy(WBUFP(buf,90),nd->name,24);
-#endif
-	return len;
+	return clif_spawn_build7b(&info, buf);
 }
 
 /*==========================================
@@ -3096,435 +2229,57 @@ static int clif_npc007b(struct npc_data *nd,unsigned char *buf,struct map_sessio
  */
 static int clif_pet0078(struct pet_data *pd,unsigned char *buf)
 {
-	int len, view;
+	struct clif_spawn_info info;
+	int view;
 
 	nullpo_retr(0, pd);
 
+	memset(&info, 0, sizeof(info));
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME;
+	info.id = pd->bl.id;
+	info.speed = pd->speed;
+	info.view_class = mob_get_viewclass(pd->class_);
+	info.x = pd->bl.x;
+	info.y = pd->bl.y;
+	info.dir = (unsigned char)pd->dir;
+	info.level = status_get_lv(&pd->bl);
+	info.level_class = mob_get_viewclass(pd->class_);
+	info.name = pd->name;
+
 	if(mob_is_pcview(pd->class_)) {
-#if PACKETVER < 4
-		len = packet_db[0x78].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x78;
-		WBUFL(buf,2)=pd->bl.id;
-		WBUFW(buf,6)=pd->speed;
-		WBUFW(buf,12)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,14)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,16)=mob_get_hair(pd->class_);
-		WBUFW(buf,18)=mob_get_weapon(pd->class_);
-		WBUFW(buf,20)=mob_get_head_bottom(pd->class_);
-		WBUFW(buf,22)=mob_get_shield(pd->class_);
-		WBUFW(buf,24)=mob_get_head_top(pd->class_);
-		WBUFW(buf,26)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,28)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,30)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,45)=mob_get_sex(pd->class_);
-		WBUFPOS(buf,46,pd->bl.x,pd->bl.y,pd->dir);
-		WBUFB(buf,49)=0;
-		WBUFB(buf,50)=0;
-		WBUFLV(buf,52,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-#elif PACKETVER < 7
-		len = packet_db[0x1d8].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x1d8;
-		WBUFL(buf,2)=pd->bl.id;
-		WBUFW(buf,6)=pd->speed;
-		WBUFW(buf,12)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,14)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,16)=mob_get_hair(pd->class_);
-		WBUFW(buf,18)=mob_get_weapon(pd->class_);
-		WBUFW(buf,20)=mob_get_shield(pd->class_);
-		WBUFW(buf,22)=mob_get_head_bottom(pd->class_);
-		WBUFW(buf,24)=mob_get_head_top(pd->class_);
-		WBUFW(buf,26)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,28)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,30)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,45)=mob_get_sex(pd->class_);
-		WBUFPOS(buf,46,pd->bl.x,pd->bl.y,pd->dir);
-		WBUFB(buf,49)=0;
-		WBUFB(buf,50)=0;
-		WBUFLV(buf,52,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-#elif PACKETVER < 20080102
-		len = packet_db[0x22a].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x22a;
-		WBUFL(buf,2)=pd->bl.id;
-		WBUFW(buf,6)=pd->speed;
-		WBUFL(buf,12)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,16)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,18)=mob_get_hair(pd->class_);
-		WBUFW(buf,20)=mob_get_weapon(pd->class_);
-		WBUFW(buf,22)=mob_get_shield(pd->class_);
-		WBUFW(buf,24)=mob_get_head_bottom(pd->class_);
-		WBUFW(buf,26)=mob_get_head_top(pd->class_);
-		WBUFW(buf,28)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,30)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,32)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,49)=mob_get_sex(pd->class_);
-		WBUFPOS(buf,50,pd->bl.x,pd->bl.y,pd->dir);
-		WBUFB(buf,53)=0;
-		WBUFB(buf,54)=0;
-		WBUFLV(buf,56,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-#elif PACKETVER < 20091104
-		len = packet_db[0x2ee].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x2ee;
-		WBUFL(buf,2)=pd->bl.id;
-		WBUFW(buf,6)=pd->speed;
-		WBUFL(buf,12)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,16)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,18)=mob_get_hair(pd->class_);
-		WBUFW(buf,20)=mob_get_weapon(pd->class_);
-		WBUFW(buf,22)=mob_get_shield(pd->class_);
-		WBUFW(buf,24)=mob_get_head_bottom(pd->class_);
-		WBUFW(buf,26)=mob_get_head_top(pd->class_);
-		WBUFW(buf,28)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,30)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,32)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,49)=mob_get_sex(pd->class_);
-		WBUFPOS(buf,50,pd->bl.x,pd->bl.y,pd->dir);
-		WBUFB(buf,53)=0;
-		WBUFB(buf,54)=0;
-		WBUFLV(buf,56,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		WBUFW(buf,58)=0;
-#elif PACKETVER < 20110111
-		len = 63 + (int)strlen(pd->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x7f9;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFW(buf,9)=pd->speed;
-		WBUFL(buf,15)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,21)=mob_get_hair(pd->class_);
-		WBUFW(buf,23)=mob_get_weapon(pd->class_);
-		WBUFW(buf,25)=mob_get_shield(pd->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(pd->class_);
-		WBUFW(buf,29)=mob_get_head_top(pd->class_);
-		WBUFW(buf,31)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,33)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,35)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,52)=mob_get_sex(pd->class_);
-		WBUFPOS(buf,53,pd->bl.x,pd->bl.y,pd->dir);
-		WBUFB(buf,56)=5;
-		WBUFB(buf,57)=5;
-		WBUFLV(buf,59,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		strncpy(WBUFP(buf,63),pd->name,24);
-#elif PACKETVER < 20120328
-		len = 65 + (int)strlen(pd->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x857;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFW(buf,9)=pd->speed;
-		WBUFL(buf,15)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,21)=mob_get_hair(pd->class_);
-		WBUFW(buf,23)=mob_get_weapon(pd->class_);
-		WBUFW(buf,25)=mob_get_shield(pd->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(pd->class_);
-		WBUFW(buf,29)=mob_get_head_top(pd->class_);
-		WBUFW(buf,31)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,33)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,35)=mob_get_clothes_color(pd->class_);
-		WBUFW(buf,39)=mob_get_robe(pd->class_);
-		WBUFB(buf,54)=mob_get_sex(pd->class_);
-		WBUFPOS(buf,55,pd->bl.x,pd->bl.y,pd->dir);
-		WBUFB(buf,58)=5;
-		WBUFB(buf,59)=5;
-		WBUFLV(buf,61,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		strncpy(WBUFP(buf,65),pd->name,24);
-#elif PACKETVER < 20131223
-		len = 74;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x915;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFW(buf,9)=pd->speed;
-		WBUFL(buf,15)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,21)=mob_get_hair(pd->class_);
-		WBUFW(buf,23)=mob_get_weapon(pd->class_);
-		WBUFW(buf,25)=mob_get_shield(pd->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(pd->class_);
-		WBUFW(buf,29)=mob_get_head_top(pd->class_);
-		WBUFW(buf,31)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,33)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,35)=mob_get_clothes_color(pd->class_);
-		WBUFW(buf,39)=mob_get_robe(pd->class_);
-		WBUFB(buf,54)=mob_get_sex(pd->class_);
-		WBUFPOS(buf,55,pd->bl.x,pd->bl.y,pd->dir);
-		WBUFB(buf,58)=5;
-		WBUFB(buf,59)=5;
-		WBUFLV(buf,61,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		WBUFL(buf,65) = 0xffffffff;
-		WBUFL(buf,69) = 0xffffffff;
-		WBUFB(buf,73) = 0;
-#elif PACKETVER < 20150513
-		len = 78 + (int)strlen(pd->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9dd;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=pd->speed;
-		WBUFL(buf,19)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,25)=mob_get_hair(pd->class_);
-		WBUFW(buf,27)=mob_get_weapon(pd->class_);
-		WBUFW(buf,29)=mob_get_shield(pd->class_);
-		WBUFW(buf,31)=mob_get_head_bottom(pd->class_);
-		WBUFW(buf,33)=mob_get_head_top(pd->class_);
-		WBUFW(buf,35)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,37)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,39)=mob_get_clothes_color(pd->class_);
-		WBUFW(buf,43)=mob_get_robe(pd->class_);
-		WBUFB(buf,58)=mob_get_sex(pd->class_);
-		WBUFPOS(buf,59,pd->bl.x,pd->bl.y,pd->dir);
-		WBUFB(buf,62)=5;
-		WBUFB(buf,63)=5;
-		WBUFLV(buf,65,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		WBUFL(buf,69) = 0xffffffff;
-		WBUFL(buf,73) = 0xffffffff;
-		WBUFB(buf,77) = 0;
-		strncpy(WBUFP(buf,78),pd->name,24);
-#elif PACKETVER < 20180704
-		len = 80 + (int)strlen(pd->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9ff;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=pd->speed;
-		WBUFL(buf,19)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,25)=mob_get_hair(pd->class_);
-		WBUFW(buf,27)=mob_get_weapon(pd->class_);
-		WBUFW(buf,29)=mob_get_shield(pd->class_);
-		WBUFW(buf,31)=mob_get_head_bottom(pd->class_);
-		WBUFW(buf,33)=mob_get_head_top(pd->class_);
-		WBUFW(buf,35)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,37)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,39)=mob_get_clothes_color(pd->class_);
-		WBUFW(buf,43)=mob_get_robe(pd->class_);
-		WBUFB(buf,58)=mob_get_sex(pd->class_);
-		WBUFPOS(buf,59,pd->bl.x,pd->bl.y,pd->dir);
-		WBUFB(buf,62)=5;
-		WBUFB(buf,63)=5;
-		WBUFLV(buf,65,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		WBUFL(buf,69) = 0xffffffff;
-		WBUFL(buf,73) = 0xffffffff;
-		WBUFB(buf,77) = 0;
-		WBUFW(buf,78) = 0;
-		strncpy(WBUFP(buf,80),pd->name,24);
+		info.packet_style = CLIF_SPAWN_STYLE_PC;
+		info.option = mobdb_search(pd->class_)->option;
+		info.hair = mob_get_hair(pd->class_);
+		info.weapon = mob_get_weapon(pd->class_);
+		info.shield = mob_get_shield(pd->class_);
+		info.head_bottom = mob_get_head_bottom(pd->class_);
+		info.head_top = mob_get_head_top(pd->class_);
+		info.head_mid = mob_get_head_mid(pd->class_);
+		info.hair_color = mob_get_hair_color(pd->class_);
+		info.clothes_color = mob_get_clothes_color(pd->class_);
+		info.robe = mob_get_robe(pd->class_);
+		info.sex = mob_get_sex(pd->class_);
+#if PACKETVER < 20091104
+		info.xsize = 0;
+		info.ysize = 0;
 #else
-		len = 84 + (int)strlen(pd->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9ff;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=pd->speed;
-		WBUFL(buf,19)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,25)=mob_get_hair(pd->class_);
-		WBUFL(buf,27)=mob_get_weapon(pd->class_);
-		WBUFL(buf,31)=mob_get_shield(pd->class_);
-		WBUFW(buf,35)=mob_get_head_bottom(pd->class_);
-		WBUFW(buf,37)=mob_get_head_top(pd->class_);
-		WBUFW(buf,39)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,41)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,43)=mob_get_clothes_color(pd->class_);
-		WBUFW(buf,47)=mob_get_robe(pd->class_);
-		WBUFB(buf,62)=mob_get_sex(pd->class_);
-		WBUFPOS(buf,63,pd->bl.x,pd->bl.y,pd->dir);
-		WBUFB(buf,66)=5;
-		WBUFB(buf,67)=5;
-		WBUFLV(buf,69,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		WBUFL(buf,73) = 0xffffffff;
-		WBUFL(buf,77) = 0xffffffff;
-		WBUFB(buf,81) = 0;
-		WBUFW(buf,82) = 0;
-		strncpy(WBUFP(buf,84),pd->name,24);
+		info.xsize = 5;
+		info.ysize = 5;
 #endif
-		return len;
+		return clif_spawn_build78(&info, buf);
 	}
-#if PACKETVER < 20071106
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
 
-	WBUFW(buf,0)=0x78;
-	WBUFL(buf,2)=pd->bl.id;
-	WBUFW(buf,6)=pd->speed;
-	WBUFW(buf,14)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,16)=battle_config.pet0078_hair_id;
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.objecttype = 7;
+	info.hair = battle_config.pet0078_hair_id;
 	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,20)=view;
+		info.head_bottom = view;
 	else
-		WBUFW(buf,20)=pd->equip;
-	WBUFPOS(buf,46,pd->bl.x,pd->bl.y,pd->dir);
-	WBUFB(buf,49)=0;
-	WBUFB(buf,50)=0;
-	WBUFLV(buf,52,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-#elif PACKETVER < 20091104
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x78;
-	WBUFB(buf,2)=0;
-	WBUFL(buf,3)=pd->bl.id;
-	WBUFW(buf,7)=pd->speed;
-	WBUFW(buf,15)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,17)=battle_config.pet0078_hair_id;
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,21)=view;
-	else
-		WBUFW(buf,21)=pd->equip;
-	WBUFPOS(buf,47,pd->bl.x,pd->bl.y,pd->dir);
-	WBUFB(buf,50)=0;
-	WBUFB(buf,51)=0;
-	WBUFLV(buf,53,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-#elif PACKETVER < 20110111
-	len = 63 + (int)strlen(pd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x7f9;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFW(buf,9)=pd->speed;
-	WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,21)=100;	// 調べた限り固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,27)=view;
-	else
-		WBUFW(buf,27)=pd->equip;
-	WBUFPOS(buf,53,pd->bl.x,pd->bl.y,pd->dir);
-	WBUFLV(buf,59,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	strncpy(WBUFP(buf,63),pd->name,24);
-#elif PACKETVER < 20120328
-	len = 65 + (int)strlen(pd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x857;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFW(buf,9)=pd->speed;
-	WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,21)=100;	// 調べた限り固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,27)=view;
-	else
-		WBUFW(buf,27)=pd->equip;
-	WBUFPOS(buf,55,pd->bl.x,pd->bl.y,pd->dir);
-	WBUFLV(buf,61,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	strncpy(WBUFP(buf,65),pd->name,24);
-#elif PACKETVER < 20131223
-	len = 74;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x915;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFW(buf,9)=pd->speed;
-	WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,21)=100;	// 調べた限り固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,27)=view;
-	else
-		WBUFW(buf,27)=pd->equip;
-	WBUFPOS(buf,55,pd->bl.x,pd->bl.y,pd->dir);
-	WBUFLV(buf,61,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	WBUFL(buf,65) = 0xffffffff;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFB(buf,73) = 0;
-#elif PACKETVER < 20150513
-	len = 78 + (int)strlen(pd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9dd;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=pd->speed;
-	WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,25)=100;	// 調べた限り固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,31)=view;
-	else
-		WBUFW(buf,31)=pd->equip;
-	WBUFPOS(buf,59,pd->bl.x,pd->bl.y,pd->dir);
-	WBUFLV(buf,65,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	strncpy(WBUFP(buf,78),pd->name,24);
-#elif PACKETVER < 20180704
-	len = 80 + (int)strlen(pd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9ff;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=pd->speed;
-	WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,25)=100;	// 調べた限り固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,31)=view;
-	else
-		WBUFW(buf,31)=pd->equip;
-	WBUFPOS(buf,59,pd->bl.x,pd->bl.y,pd->dir);
-	WBUFLV(buf,65,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	WBUFW(buf,78) = 0;
-	strncpy(WBUFP(buf,80),pd->name,24);
-#else
-	len = 84 + (int)strlen(pd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9ff;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=pd->speed;
-	WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,25)=100;	// 調べた限り固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,35)=view;
-	else
-		WBUFW(buf,35)=pd->equip;
-	WBUFPOS(buf,63,pd->bl.x,pd->bl.y,pd->dir);
-	WBUFLV(buf,69,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFL(buf,77) = 0xffffffff;
-	WBUFB(buf,81) = 0;
-	WBUFW(buf,82) = 0;
-	strncpy(WBUFP(buf,84),pd->name,24);
+		info.head_bottom = pd->equip;
+#if PACKETVER >= 20110111
+	info.hair = 100;
 #endif
-	return len;
+	return clif_spawn_build78(&info, buf);
 }
 
 /*==========================================
@@ -3533,460 +2288,60 @@ static int clif_pet0078(struct pet_data *pd,unsigned char *buf)
  */
 static int clif_pet007b(struct pet_data *pd,unsigned char *buf)
 {
-	int len, view;
-	unsigned int tick = gettick();
+	struct clif_spawn_info info;
+	int view;
 
 	nullpo_retr(0, pd);
 
+	memset(&info, 0, sizeof(info));
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME;
+	info.id = pd->bl.id;
+	info.speed = pd->speed;
+	info.view_class = mob_get_viewclass(pd->class_);
+	info.x = pd->bl.x;
+	info.y = pd->bl.y;
+	info.to_x = pd->ud.to_x;
+	info.to_y = pd->ud.to_y;
+	info.level = status_get_lv(&pd->bl);
+	info.level_class = mob_get_viewclass(pd->class_);
+	info.name = pd->name;
+	info.style = mob_get_style(pd->class_);
+
 	if(mob_is_pcview(pd->class_)) {
-#if PACKETVER < 4
-		len = packet_db[0x7b].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x7b;
-		WBUFL(buf,2)=pd->bl.id;
-		WBUFW(buf,6)=pd->speed;
-		WBUFW(buf,12)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,14)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,16)=mob_get_hair(pd->class_);
-		WBUFW(buf,18)=mob_get_weapon(pd->class_);
-		WBUFW(buf,20)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,22)=tick;
-		WBUFW(buf,26)=mob_get_shield(pd->class_);
-		WBUFW(buf,28)=mob_get_head_top(pd->class_);
-		WBUFW(buf,30)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,32)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,34)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,49)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,50,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,56)=0;
-		WBUFB(buf,57)=0;
-		WBUFLV(buf,58,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-#elif PACKETVER < 7
-		len = packet_db[0x1da].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x1da;
-		WBUFL(buf,2)=pd->bl.id;
-		WBUFW(buf,6)=pd->speed;
-		WBUFW(buf,12)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,14)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,16)=mob_get_hair(pd->class_);
-		WBUFW(buf,18)=mob_get_weapon(pd->class_);
-		WBUFW(buf,20)=mob_get_shield(pd->class_);
-		WBUFW(buf,22)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,24)=tick;
-		WBUFW(buf,28)=mob_get_head_top(pd->class_);
-		WBUFW(buf,30)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,32)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,34)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,49)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,50,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,56)=0;
-		WBUFB(buf,57)=0;
-		WBUFLV(buf,58,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-#elif PACKETVER < 20071106
-		len = packet_db[0x22c].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x22c;
-		WBUFL(buf,2)=pd->bl.id;
-		WBUFW(buf,6)=pd->speed;
-		WBUFL(buf,12)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,16)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,18)=mob_get_hair(pd->class_);
-		WBUFW(buf,20)=mob_get_weapon(pd->class_);
-		WBUFW(buf,22)=mob_get_shield(pd->class_);
-		WBUFW(buf,24)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,26)=tick;
-		WBUFW(buf,30)=mob_get_head_top(pd->class_);
-		WBUFW(buf,32)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,34)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,36)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,53)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,54,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,60)=0;
-		WBUFB(buf,61)=0;
-		WBUFLV(buf,62,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-#elif PACKETVER < 20080102
-		len = packet_db[0x22c].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x22c;
-		WBUFB(buf,2)=0;
-		WBUFL(buf,3)=pd->bl.id;
-		WBUFW(buf,7)=pd->speed;
-		WBUFL(buf,13)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,17)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,19)=mob_get_hair(pd->class_);
-		WBUFW(buf,21)=mob_get_weapon(pd->class_);
-		WBUFW(buf,23)=mob_get_shield(pd->class_);
-		WBUFW(buf,25)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,27)=tick;
-		WBUFW(buf,31)=mob_get_head_top(pd->class_);
-		WBUFW(buf,33)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,35)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,37)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,54)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,55,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,61)=0;
-		WBUFB(buf,62)=0;
-		WBUFLV(buf,63,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-#elif PACKETVER < 20091104
-		len = packet_db[0x2ec].len;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x2ec;
-		WBUFB(buf,2)=0;
-		WBUFL(buf,3)=pd->bl.id;
-		WBUFW(buf,7)=pd->speed;
-		WBUFL(buf,13)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,17)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,19)=mob_get_hair(pd->class_);
-		WBUFW(buf,21)=mob_get_weapon(pd->class_);
-		WBUFW(buf,23)=mob_get_shield(pd->class_);
-		WBUFW(buf,25)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,27)=tick;
-		WBUFW(buf,31)=mob_get_head_top(pd->class_);
-		WBUFW(buf,33)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,35)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,37)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,54)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,55,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,61)=0;
-		WBUFB(buf,62)=0;
-		WBUFLV(buf,63,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		WBUFW(buf,65)=0;
-#elif PACKETVER < 20110111
-		len = 69 + (int)strlen(pd->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x7f7;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFW(buf,9)=pd->speed;
-		WBUFL(buf,15)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,21)=mob_get_hair(pd->class_);
-		WBUFW(buf,23)=mob_get_weapon(pd->class_);
-		WBUFW(buf,25)=mob_get_shield(pd->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,29)=tick;
-		WBUFW(buf,33)=mob_get_head_top(pd->class_);
-		WBUFW(buf,35)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,37)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,39)=mob_get_clothes_color(pd->class_);
-		WBUFB(buf,56)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,57,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,63)=5;
-		WBUFB(buf,64)=5;
-		WBUFLV(buf,65,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		strncpy(WBUFP(buf,69),pd->name,24);
-#elif PACKETVER < 20120328
-		len = 71 + (int)strlen(pd->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x856;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFW(buf,9)=pd->speed;
-		WBUFL(buf,15)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,21)=mob_get_hair(pd->class_);
-		WBUFW(buf,23)=mob_get_weapon(pd->class_);
-		WBUFW(buf,25)=mob_get_shield(pd->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,29)=tick;
-		WBUFW(buf,33)=mob_get_head_top(pd->class_);
-		WBUFW(buf,35)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,37)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,39)=mob_get_clothes_color(pd->class_);
-		WBUFW(buf,43)=mob_get_robe(pd->class_);
-		WBUFB(buf,58)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,59,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,65)=5;
-		WBUFB(buf,66)=5;
-		WBUFLV(buf,67,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		strncpy(WBUFP(buf,71),pd->name,24);
-#elif PACKETVER < 20131223
-		len = 80;
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x914;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFW(buf,9)=pd->speed;
-		WBUFL(buf,15)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,21)=mob_get_hair(pd->class_);
-		WBUFW(buf,23)=mob_get_weapon(pd->class_);
-		WBUFW(buf,25)=mob_get_shield(pd->class_);
-		WBUFW(buf,27)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,29)=tick;
-		WBUFW(buf,33)=mob_get_head_top(pd->class_);
-		WBUFW(buf,35)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,37)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,39)=mob_get_clothes_color(pd->class_);
-		WBUFW(buf,43)=mob_get_robe(pd->class_);
-		WBUFB(buf,58)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,59,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,65)=5;
-		WBUFB(buf,66)=5;
-		WBUFLV(buf,67,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		WBUFL(buf,71) = 0xffffffff;
-		WBUFL(buf,75) = 0xffffffff;
-		WBUFB(buf,79) = 0;
-#elif PACKETVER < 20150513
-		len = 84 + (int)strlen(pd->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9db;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=pd->speed;
-		WBUFL(buf,19)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,25)=mob_get_hair(pd->class_);
-		WBUFW(buf,27)=mob_get_weapon(pd->class_);
-		WBUFW(buf,29)=mob_get_shield(pd->class_);
-		WBUFW(buf,31)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,33)=tick;
-		WBUFW(buf,37)=mob_get_head_top(pd->class_);
-		WBUFW(buf,39)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,41)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,43)=mob_get_clothes_color(pd->class_);
-		WBUFW(buf,47)=mob_get_robe(pd->class_);
-		WBUFB(buf,62)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,63,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,69)=5;
-		WBUFB(buf,70)=5;
-		WBUFLV(buf,71,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		WBUFL(buf,75) = 0xffffffff;
-		WBUFL(buf,79) = 0xffffffff;
-		WBUFB(buf,83) = 0;
-		strncpy(WBUFP(buf,84),pd->name,24);
-#elif PACKETVER < 20180704
-		len = 86 + (int)strlen(pd->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9fd;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=pd->speed;
-		WBUFL(buf,19)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,25)=mob_get_hair(pd->class_);
-		WBUFW(buf,27)=mob_get_weapon(pd->class_);
-		WBUFW(buf,29)=mob_get_shield(pd->class_);
-		WBUFW(buf,31)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,33)=tick;
-		WBUFW(buf,37)=mob_get_head_top(pd->class_);
-		WBUFW(buf,39)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,41)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,43)=mob_get_clothes_color(pd->class_);
-		WBUFW(buf,47)=mob_get_robe(pd->class_);
-		WBUFB(buf,62)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,63,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,69)=5;
-		WBUFB(buf,70)=5;
-		WBUFLV(buf,71,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		WBUFL(buf,75) = 0xffffffff;
-		WBUFL(buf,79) = 0xffffffff;
-		WBUFB(buf,83) = 0;
-		WBUFW(buf,84) = mob_get_style(pd->class_);
-		strncpy(WBUFP(buf,86),pd->name,24);
-#else
-		len = 90 + (int)strlen(pd->name);
-		memset(buf,0,len);
-
-		WBUFW(buf,0)=0x9fd;
-		WBUFW(buf,2)=(unsigned short)len;
-		WBUFB(buf,4)=0;
-		WBUFL(buf,5)=pd->bl.id;
-		WBUFL(buf,9)=0;
-		WBUFW(buf,13)=pd->speed;
-		WBUFL(buf,19)=mobdb_search(pd->class_)->option;
-		WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-		WBUFW(buf,25)=mob_get_hair(pd->class_);
-		WBUFL(buf,27)=mob_get_weapon(pd->class_);
-		WBUFL(buf,31)=mob_get_shield(pd->class_);
-		WBUFW(buf,35)=mob_get_head_bottom(pd->class_);
-		WBUFL(buf,37)=tick;
-		WBUFW(buf,41)=mob_get_head_top(pd->class_);
-		WBUFW(buf,43)=mob_get_head_mid(pd->class_);
-		WBUFW(buf,45)=mob_get_hair_color(pd->class_);
-		WBUFW(buf,47)=mob_get_clothes_color(pd->class_);
-		WBUFW(buf,51)=mob_get_robe(pd->class_);
-		WBUFB(buf,66)=mob_get_sex(pd->class_);
-		WBUFPOS2(buf,67,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-		WBUFB(buf,73)=5;
-		WBUFB(buf,74)=5;
-		WBUFLV(buf,75,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-		WBUFL(buf,79) = 0xffffffff;
-		WBUFL(buf,83) = 0xffffffff;
-		WBUFB(buf,87) = 0;
-		WBUFW(buf,88) = mob_get_style(pd->class_);
-		strncpy(WBUFP(buf,90),pd->name,24);
-#endif
-		return len;
-	}
+		info.packet_style = CLIF_SPAWN_STYLE_PC;
+		info.option = mobdb_search(pd->class_)->option;
+		info.hair = mob_get_hair(pd->class_);
+		info.weapon = mob_get_weapon(pd->class_);
+		info.shield = mob_get_shield(pd->class_);
+		info.head_bottom = mob_get_head_bottom(pd->class_);
+		info.head_top = mob_get_head_top(pd->class_);
+		info.head_mid = mob_get_head_mid(pd->class_);
+		info.hair_color = mob_get_hair_color(pd->class_);
+		info.clothes_color = mob_get_clothes_color(pd->class_);
+		info.robe = mob_get_robe(pd->class_);
+		info.sex = mob_get_sex(pd->class_);
 #if PACKETVER < 20091104
-	len = packet_db[0x7b].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x7b;
-	WBUFL(buf,2)=pd->bl.id;
-	WBUFW(buf,6)=pd->speed;
-	WBUFW(buf,14)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,16)=battle_config.pet0078_hair_id;
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,20)=view;
-	else
-		WBUFW(buf,20)=pd->equip;
-	WBUFL(buf,22)=tick;
-	WBUFPOS2(buf,50,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-	WBUFB(buf,56)=0;
-	WBUFB(buf,57)=0;
-	WBUFLV(buf,58,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-#elif PACKETVER < 20110111
-	len = 69 + (int)strlen(pd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x7f7;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFW(buf,9)=pd->speed;
-	WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,21)=100;	// 調べた限りでは固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,27)=view;
-	else
-		WBUFW(buf,27)=pd->equip;
-	WBUFL(buf,29)=tick;
-	WBUFPOS2(buf,57,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-	WBUFLV(buf,65,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	strncpy(WBUFP(buf,69),pd->name,24);
-#elif PACKETVER < 20120328
-	len = 71 + (int)strlen(pd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x856;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFW(buf,9)=pd->speed;
-	WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,21)=100;	// 調べた限りでは固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,27)=view;
-	else
-		WBUFW(buf,27)=pd->equip;
-	WBUFL(buf,29)=tick;
-	WBUFPOS2(buf,59,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-	WBUFLV(buf,67,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	strncpy(WBUFP(buf,71),pd->name,24);
-#elif PACKETVER < 20131223
-	len = 80;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x914;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFW(buf,9)=pd->speed;
-	WBUFW(buf,19)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,21)=100;	// 調べた限りでは固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,27)=view;
-	else
-		WBUFW(buf,27)=pd->equip;
-	WBUFL(buf,29)=tick;
-	WBUFPOS2(buf,59,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-	WBUFLV(buf,67,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	WBUFL(buf,71) = 0xffffffff;
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFB(buf,79) = 0;
-#elif PACKETVER < 20150513
-	len = 84 + (int)strlen(pd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9db;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=pd->speed;
-	WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,25)=100;	// 調べた限りでは固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,31)=view;
-	else
-		WBUFW(buf,31)=pd->equip;
-	WBUFL(buf,33)=tick;
-	WBUFPOS2(buf,63,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-	WBUFLV(buf,71,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	strncpy(WBUFP(buf,84),pd->name,24);
-#elif PACKETVER < 20180704
-	len = 86 + (int)strlen(pd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9fd;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=pd->speed;
-	WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,25)=100;	// 調べた限りでは固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,31)=view;
-	else
-		WBUFW(buf,31)=pd->equip;
-	WBUFL(buf,33)=tick;
-	WBUFPOS2(buf,63,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-	WBUFLV(buf,71,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	WBUFW(buf,84) = 0;
-	strncpy(WBUFP(buf,86),pd->name,24);
+		info.xsize = 0;
+		info.ysize = 0;
 #else
-	len = 90 + (int)strlen(pd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9fd;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=7;
-	WBUFL(buf,5)=pd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=pd->speed;
-	WBUFW(buf,23)=mob_get_viewclass(pd->class_);
-	WBUFW(buf,25)=100;	// 調べた限りでは固定
-	if((view = itemdb_viewid(pd->equip)) > 0)
-		WBUFW(buf,35)=view;
-	else
-		WBUFW(buf,35)=pd->equip;
-	WBUFL(buf,37)=tick;
-	WBUFPOS2(buf,67,pd->bl.x,pd->bl.y,pd->ud.to_x,pd->ud.to_y,8,8);
-	WBUFLV(buf,75,status_get_lv(&pd->bl),mob_get_viewclass(pd->class_));
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFL(buf,83) = 0xffffffff;
-	WBUFB(buf,87) = 0;
-	WBUFW(buf,88) = 0;
-	strncpy(WBUFP(buf,90),pd->name,24);
+		info.xsize = 5;
+		info.ysize = 5;
 #endif
-	return len;
+		return clif_spawn_build7b(&info, buf);
+	}
+
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.objecttype = 7;
+	info.hair = battle_config.pet0078_hair_id;
+	if((view = itemdb_viewid(pd->equip)) > 0)
+		info.head_bottom = view;
+	else
+		info.head_bottom = pd->equip;
+#if PACKETVER >= 20110111
+	info.hair = 100;
+#endif
+	info.style = 0; /* non-pcview pet style stays 0 */
+	return clif_spawn_build7b(&info, buf);
 }
 
 /*==========================================
@@ -3995,173 +2350,32 @@ static int clif_pet007b(struct pet_data *pd,unsigned char *buf)
  */
 static int clif_hom0078(struct homun_data *hd,unsigned char *buf)
 {
-	int len;
+	struct clif_spawn_info info;
 
 	nullpo_retr(0, hd);
 
-#if PACKETVER < 20071106
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x78;
-	WBUFL(buf,2) =hd->bl.id;
-	WBUFW(buf,6) =hd->speed;
-	WBUFW(buf,8) =hd->sc.opt1;
-	WBUFW(buf,10)=hd->sc.opt2;
-	WBUFW(buf,12)=hd->sc.option;
-	WBUFW(buf,14)=hd->view_class;
-	WBUFW(buf,16)=battle_config.pet0078_hair_id;
-	WBUFW(buf,20)=0;
-	WBUFW(buf,42)=hd->sc.opt3;
-	WBUFPOS(buf,46,hd->bl.x,hd->bl.y,hd->dir);
-	WBUFB(buf,49)=0;
-	WBUFB(buf,50)=0;
-	WBUFLV(buf,52,status_get_lv(&hd->bl),hd->view_class);
-#elif PACKETVER < 20091104
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x78;
-	WBUFB(buf,2) =0;
-	WBUFL(buf,3) =hd->bl.id;
-	WBUFW(buf,7) =hd->speed;
-	WBUFW(buf,9) =hd->sc.opt1;
-	WBUFW(buf,11)=hd->sc.opt2;
-	WBUFW(buf,13)=hd->sc.option;
-	WBUFW(buf,15)=hd->view_class;
-	WBUFW(buf,17)=battle_config.pet0078_hair_id;
-	WBUFW(buf,21)=0;
-	WBUFW(buf,43)=hd->sc.opt3;
-	WBUFPOS(buf,47,hd->bl.x,hd->bl.y,hd->dir);
-	WBUFB(buf,50)=0;
-	WBUFB(buf,51)=0;
-	WBUFLV(buf,53,status_get_lv(&hd->bl),hd->view_class);
-#elif PACKETVER < 20110111
-	len = 63 + (int)strlen(hd->status.name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x7f9;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=8;
-	WBUFL(buf,5)=hd->bl.id;
-	WBUFW(buf,9)=hd->speed;
-	WBUFW(buf,11)=hd->sc.opt1;
-	WBUFW(buf,13)=hd->sc.opt2;
-	WBUFL(buf,15)=hd->sc.option;
-	WBUFW(buf,19)=hd->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,47)=hd->sc.opt3;
-	WBUFPOS(buf,53,hd->bl.x,hd->bl.y,hd->dir);
-	WBUFLV(buf,59,status_get_lv(&hd->bl),hd->view_class);
-	strncpy(WBUFP(buf,63),hd->status.name,24);
-#elif PACKETVER < 20120328
-	len = 65 + (int)strlen(hd->status.name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x857;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=8;
-	WBUFL(buf,5)=hd->bl.id;
-	WBUFW(buf,9)=hd->speed;
-	WBUFW(buf,11)=hd->sc.opt1;
-	WBUFW(buf,13)=hd->sc.opt2;
-	WBUFL(buf,15)=hd->sc.option;
-	WBUFW(buf,19)=hd->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,49)=hd->sc.opt3;
-	WBUFPOS(buf,55,hd->bl.x,hd->bl.y,hd->dir);
-	WBUFLV(buf,61,status_get_lv(&hd->bl),hd->view_class);
-	strncpy(WBUFP(buf,65),hd->status.name,24);
-#elif PACKETVER < 20131223
-	len = 74;
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x915;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=8;
-	WBUFL(buf,5)=hd->bl.id;
-	WBUFW(buf,9)=hd->speed;
-	WBUFW(buf,11)=hd->sc.opt1;
-	WBUFW(buf,13)=hd->sc.opt2;
-	WBUFL(buf,15)=hd->sc.option;
-	WBUFW(buf,19)=hd->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,49)=hd->sc.opt3;
-	WBUFPOS(buf,55,hd->bl.x,hd->bl.y,hd->dir);
-	WBUFLV(buf,61,status_get_lv(&hd->bl),hd->view_class);
-	WBUFL(buf,65) = 0xffffffff;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFB(buf,73) = 0;
-#elif PACKETVER < 20150513
-	len = 78 + (int)strlen(hd->status.name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9dd;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=8;
-	WBUFL(buf,5)=hd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=hd->speed;
-	WBUFW(buf,15)=hd->sc.opt1;
-	WBUFW(buf,17)=hd->sc.opt2;
-	WBUFL(buf,19)=hd->sc.option;
-	WBUFW(buf,23)=hd->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,53)=hd->sc.opt3;
-	WBUFPOS(buf,59,hd->bl.x,hd->bl.y,hd->dir);
-	WBUFLV(buf,65,status_get_lv(&hd->bl),hd->view_class);
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	strncpy(WBUFP(buf,78),hd->status.name,24);
-#elif PACKETVER < 20180704
-	len = 80 + (int)strlen(hd->status.name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9ff;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=8;
-	WBUFL(buf,5)=hd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=hd->speed;
-	WBUFW(buf,15)=hd->sc.opt1;
-	WBUFW(buf,17)=hd->sc.opt2;
-	WBUFL(buf,19)=hd->sc.option;
-	WBUFW(buf,23)=hd->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,53)=hd->sc.opt3;
-	WBUFPOS(buf,59,hd->bl.x,hd->bl.y,hd->dir);
-	WBUFLV(buf,65,status_get_lv(&hd->bl),hd->view_class);
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	WBUFW(buf,78) = 0;
-	strncpy(WBUFP(buf,80),hd->status.name,24);
-#else
-	len = 84 + (int)strlen(hd->status.name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0)=0x9ff;
-	WBUFW(buf,2)=(unsigned short)len;
-	WBUFB(buf,4)=8;
-	WBUFL(buf,5)=hd->bl.id;
-	WBUFL(buf,9)=0;
-	WBUFW(buf,13)=hd->speed;
-	WBUFW(buf,15)=hd->sc.opt1;
-	WBUFW(buf,17)=hd->sc.opt2;
-	WBUFL(buf,19)=hd->sc.option;
-	WBUFW(buf,23)=hd->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,57)=hd->sc.opt3;
-	WBUFPOS(buf,63,hd->bl.x,hd->bl.y,hd->dir);
-	WBUFLV(buf,69,status_get_lv(&hd->bl),hd->view_class);
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFL(buf,77) = 0xffffffff;
-	WBUFB(buf,81) = 0;
-	WBUFW(buf,82) = 0;
-	strncpy(WBUFP(buf,84),hd->status.name,24);
+	memset(&info, 0, sizeof(info));
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME;
+	info.id = hd->bl.id;
+	info.speed = hd->speed;
+	info.opt1 = hd->sc.opt1;
+	info.opt2 = hd->sc.opt2;
+	info.option = hd->sc.option;
+	info.opt3 = hd->sc.opt3;
+	info.view_class = hd->view_class;
+	info.hair = battle_config.pet0078_hair_id;
+	info.x = hd->bl.x;
+	info.y = hd->bl.y;
+	info.dir = (unsigned char)hd->dir;
+	info.level = status_get_lv(&hd->bl);
+	info.level_class = hd->view_class;
+	info.name = hd->status.name;
+	info.objecttype = 8;
+#if PACKETVER >= 20110111
+	info.hair = 100;
 #endif
-	return len;
+	return clif_spawn_build78(&info, buf);
 }
 
 /*==========================================
@@ -4170,189 +2384,38 @@ static int clif_hom0078(struct homun_data *hd,unsigned char *buf)
  */
 static int clif_hom007b(struct homun_data *hd,unsigned char *buf)
 {
-	int len, view;
-	unsigned int tick = gettick();
+	struct clif_spawn_info info;
+	int view;
 
 	nullpo_retr(0, hd);
 
-#if PACKETVER < 20091104
-	len = packet_db[0x7b].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x7b;
-	WBUFL(buf,2) =hd->bl.id;
-	WBUFW(buf,6) =hd->speed;
-	WBUFW(buf,8) =hd->sc.opt1;
-	WBUFW(buf,10)=hd->sc.opt2;
-	WBUFW(buf,12)=hd->sc.option;
-	WBUFW(buf,14)=hd->view_class;
-	WBUFW(buf,16)=battle_config.pet0078_hair_id;
+	memset(&info, 0, sizeof(info));
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME;
+	info.id = hd->bl.id;
+	info.speed = hd->speed;
+	info.opt1 = hd->sc.opt1;
+	info.opt2 = hd->sc.opt2;
+	info.option = hd->sc.option;
+	info.opt3 = hd->sc.opt3;
+	info.view_class = hd->view_class;
+	info.hair = battle_config.pet0078_hair_id;
 	if((view = itemdb_viewid(hd->status.equip)) > 0)
-		WBUFW(buf,20)=view;
+		info.weapon = view;
 	else
-		WBUFW(buf,20)=hd->status.equip;
-	WBUFL(buf,22)=tick;
-	WBUFW(buf,46)=hd->sc.opt3;
-	WBUFPOS2(buf,50,hd->bl.x,hd->bl.y,hd->ud.to_x,hd->ud.to_y,8,8);
-	WBUFB(buf,56)=0;
-	WBUFB(buf,57)=0;
-	WBUFLV(buf,58,status_get_lv(&hd->bl),hd->view_class);
-#elif PACKETVER < 20110111
-	len = 69 + (int)strlen(hd->status.name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x7f7;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =8;
-	WBUFL(buf,5) =hd->bl.id;
-	WBUFW(buf,9) =hd->speed;
-	WBUFW(buf,11)=hd->sc.opt1;
-	WBUFW(buf,13)=hd->sc.opt2;
-	WBUFL(buf,15)=hd->sc.option;
-	WBUFW(buf,19)=hd->view_class;
-	WBUFW(buf,21)=100;
-	if((view = itemdb_viewid(hd->status.equip)) > 0)
-		WBUFW(buf,23)=view;
-	else
-		WBUFW(buf,23)=hd->status.equip;
-	WBUFL(buf,29)=tick;
-	WBUFL(buf,51)=hd->sc.opt3;
-	WBUFPOS2(buf,57,hd->bl.x,hd->bl.y,hd->ud.to_x,hd->ud.to_y,8,8);
-	WBUFLV(buf,65,status_get_lv(&hd->bl),hd->view_class);
-	strncpy(WBUFP(buf,69),hd->status.name,24);
-#elif PACKETVER < 20120328
-	len = 71 + (int)strlen(hd->status.name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x856;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =8;
-	WBUFL(buf,5) =hd->bl.id;
-	WBUFW(buf,9) =hd->speed;
-	WBUFW(buf,11)=hd->sc.opt1;
-	WBUFW(buf,13)=hd->sc.opt2;
-	WBUFL(buf,15)=hd->sc.option;
-	WBUFW(buf,19)=hd->view_class;
-	WBUFW(buf,21)=100;
-	if((view = itemdb_viewid(hd->status.equip)) > 0)
-		WBUFW(buf,23)=view;
-	else
-		WBUFW(buf,23)=hd->status.equip;
-	WBUFL(buf,29)=tick;
-	WBUFL(buf,53)=hd->sc.opt3;
-	WBUFPOS2(buf,59,hd->bl.x,hd->bl.y,hd->ud.to_x,hd->ud.to_y,8,8);
-	WBUFLV(buf,67,status_get_lv(&hd->bl),hd->view_class);
-	strncpy(WBUFP(buf,71),hd->status.name,24);
-#elif PACKETVER < 20131223
-	len = 80;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x914;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =8;
-	WBUFL(buf,5) =hd->bl.id;
-	WBUFW(buf,9) =hd->speed;
-	WBUFW(buf,11)=hd->sc.opt1;
-	WBUFW(buf,13)=hd->sc.opt2;
-	WBUFL(buf,15)=hd->sc.option;
-	WBUFW(buf,19)=hd->view_class;
-	WBUFW(buf,21)=100;
-	if((view = itemdb_viewid(hd->status.equip)) > 0)
-		WBUFW(buf,23)=view;
-	else
-		WBUFW(buf,23)=hd->status.equip;
-	WBUFL(buf,29)=tick;
-	WBUFL(buf,53)=hd->sc.opt3;
-	WBUFPOS2(buf,59,hd->bl.x,hd->bl.y,hd->ud.to_x,hd->ud.to_y,8,8);
-	WBUFLV(buf,67,status_get_lv(&hd->bl),hd->view_class);
-	WBUFL(buf,71) = 0xffffffff;
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFB(buf,79) = 0;
-#elif PACKETVER < 20150513
-	len = 84 + (int)strlen(hd->status.name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9db;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =8;
-	WBUFL(buf,5) =hd->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13) =hd->speed;
-	WBUFW(buf,15)=hd->sc.opt1;
-	WBUFW(buf,17)=hd->sc.opt2;
-	WBUFL(buf,19)=hd->sc.option;
-	WBUFW(buf,23)=hd->view_class;
-	WBUFW(buf,25)=100;
-	if((view = itemdb_viewid(hd->status.equip)) > 0)
-		WBUFW(buf,27)=view;
-	else
-		WBUFW(buf,27)=hd->status.equip;
-	WBUFL(buf,33)=tick;
-	WBUFL(buf,57)=hd->sc.opt3;
-	WBUFPOS2(buf,63,hd->bl.x,hd->bl.y,hd->ud.to_x,hd->ud.to_y,8,8);
-	WBUFLV(buf,71,status_get_lv(&hd->bl),hd->view_class);
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	strncpy(WBUFP(buf,84),hd->status.name,24);
-#elif PACKETVER < 20180704
-	len = 86 + (int)strlen(hd->status.name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9fd;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =8;
-	WBUFL(buf,5) =hd->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13) =hd->speed;
-	WBUFW(buf,15)=hd->sc.opt1;
-	WBUFW(buf,17)=hd->sc.opt2;
-	WBUFL(buf,19)=hd->sc.option;
-	WBUFW(buf,23)=hd->view_class;
-	WBUFW(buf,25)=100;
-	if((view = itemdb_viewid(hd->status.equip)) > 0)
-		WBUFW(buf,27)=view;
-	else
-		WBUFW(buf,27)=hd->status.equip;
-	WBUFL(buf,33)=tick;
-	WBUFL(buf,57)=hd->sc.opt3;
-	WBUFPOS2(buf,63,hd->bl.x,hd->bl.y,hd->ud.to_x,hd->ud.to_y,8,8);
-	WBUFLV(buf,71,status_get_lv(&hd->bl),hd->view_class);
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	WBUFW(buf,84) = 0;
-	strncpy(WBUFP(buf,86),hd->status.name,24);
-#else
-	len = 90 + (int)strlen(hd->status.name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9fd;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =8;
-	WBUFL(buf,5) =hd->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13) =hd->speed;
-	WBUFW(buf,15)=hd->sc.opt1;
-	WBUFW(buf,17)=hd->sc.opt2;
-	WBUFL(buf,19)=hd->sc.option;
-	WBUFW(buf,23)=hd->view_class;
-	WBUFW(buf,25)=100;
-	if((view = itemdb_viewid(hd->status.equip)) > 0)
-		WBUFL(buf,27)=view;
-	else
-		WBUFL(buf,27)=hd->status.equip;
-	WBUFL(buf,37)=tick;
-	WBUFL(buf,61)=hd->sc.opt3;
-	WBUFPOS2(buf,67,hd->bl.x,hd->bl.y,hd->ud.to_x,hd->ud.to_y,8,8);
-	WBUFLV(buf,75,status_get_lv(&hd->bl),hd->view_class);
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFL(buf,83) = 0xffffffff;
-	WBUFB(buf,87) = 0;
-	WBUFW(buf,88) = 0;
-	strncpy(WBUFP(buf,90),hd->status.name,24);
+		info.weapon = hd->status.equip;
+	info.x = hd->bl.x;
+	info.y = hd->bl.y;
+	info.to_x = hd->ud.to_x;
+	info.to_y = hd->ud.to_y;
+	info.level = status_get_lv(&hd->bl);
+	info.level_class = hd->view_class;
+	info.name = hd->status.name;
+	info.objecttype = 8;
+#if PACKETVER >= 20110111
+	info.hair = 100;
 #endif
-	return len;
+	return clif_spawn_build7b(&info, buf);
 }
 
 /*==========================================
@@ -4361,173 +2424,32 @@ static int clif_hom007b(struct homun_data *hd,unsigned char *buf)
  */
 static int clif_merc0078(struct merc_data *mcd,unsigned char *buf)
 {
-	int len;
+	struct clif_spawn_info info;
 
 	nullpo_retr(0, mcd);
 
-#if PACKETVER < 20071106
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x78;
-	WBUFL(buf,2) =mcd->bl.id;
-	WBUFW(buf,6) =mcd->speed;
-	WBUFW(buf,8) =mcd->sc.opt1;
-	WBUFW(buf,10)=mcd->sc.opt2;
-	WBUFW(buf,12)=mcd->sc.option;
-	WBUFW(buf,14)=mcd->view_class;
-	WBUFW(buf,16)=battle_config.pet0078_hair_id;
-	WBUFW(buf,20)=0;
-	WBUFW(buf,42)=mcd->sc.opt3;
-	WBUFPOS(buf,46,mcd->bl.x,mcd->bl.y,mcd->dir);
-	WBUFB(buf,49)=0;
-	WBUFB(buf,50)=0;
-	WBUFLV(buf,52,status_get_lv(&mcd->bl),mcd->view_class);
-#elif PACKETVER < 20091104
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x78;
-	WBUFB(buf,2) =0;
-	WBUFL(buf,3) =mcd->bl.id;
-	WBUFW(buf,7) =mcd->speed;
-	WBUFW(buf,9) =mcd->sc.opt1;
-	WBUFW(buf,11)=mcd->sc.opt2;
-	WBUFW(buf,13)=mcd->sc.option;
-	WBUFW(buf,15)=mcd->view_class;
-	WBUFW(buf,17)=battle_config.pet0078_hair_id;
-	WBUFW(buf,21)=0;
-	WBUFW(buf,43)=mcd->sc.opt3;
-	WBUFPOS(buf,47,mcd->bl.x,mcd->bl.y,mcd->dir);
-	WBUFB(buf,50)=0;
-	WBUFB(buf,51)=0;
-	WBUFLV(buf,53,status_get_lv(&mcd->bl),mcd->view_class);
-#elif PACKETVER < 20110111
-	len = 63 + (int)strlen(mcd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x7f9;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFW(buf,9) =mcd->speed;
-	WBUFW(buf,11)=mcd->sc.opt1;
-	WBUFW(buf,13)=mcd->sc.opt2;
-	WBUFL(buf,15)=mcd->sc.option;
-	WBUFW(buf,19)=mcd->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,47)=mcd->sc.opt3;
-	WBUFPOS(buf,53,mcd->bl.x,mcd->bl.y,mcd->dir);
-	WBUFLV(buf,59,status_get_lv(&mcd->bl),mcd->view_class);
-	strncpy(WBUFP(buf,63),mcd->name,24);
-#elif PACKETVER < 20120328
-	len = 65 + (int)strlen(mcd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x857;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFW(buf,9) =mcd->speed;
-	WBUFW(buf,11)=mcd->sc.opt1;
-	WBUFW(buf,13)=mcd->sc.opt2;
-	WBUFL(buf,15)=mcd->sc.option;
-	WBUFW(buf,19)=mcd->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,49)=mcd->sc.opt3;
-	WBUFPOS(buf,55,mcd->bl.x,mcd->bl.y,mcd->dir);
-	WBUFLV(buf,61,status_get_lv(&mcd->bl),mcd->view_class);
-	strncpy(WBUFP(buf,65),mcd->name,24);
-#elif PACKETVER < 20131223
-	len = 74;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x915;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFW(buf,9) =mcd->speed;
-	WBUFW(buf,11)=mcd->sc.opt1;
-	WBUFW(buf,13)=mcd->sc.opt2;
-	WBUFL(buf,15)=mcd->sc.option;
-	WBUFW(buf,19)=mcd->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,49)=mcd->sc.opt3;
-	WBUFPOS(buf,55,mcd->bl.x,mcd->bl.y,mcd->dir);
-	WBUFLV(buf,61,status_get_lv(&mcd->bl),mcd->view_class);
-	WBUFL(buf,65) = 0xffffffff;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFB(buf,73) = 0;
-#elif PACKETVER < 20150513
-	len = 78 + (int)strlen(mcd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9dd;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13) =mcd->speed;
-	WBUFW(buf,15)=mcd->sc.opt1;
-	WBUFW(buf,17)=mcd->sc.opt2;
-	WBUFL(buf,19)=mcd->sc.option;
-	WBUFW(buf,23)=mcd->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,53)=mcd->sc.opt3;
-	WBUFPOS(buf,59,mcd->bl.x,mcd->bl.y,mcd->dir);
-	WBUFLV(buf,65,status_get_lv(&mcd->bl),mcd->view_class);
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	strncpy(WBUFP(buf,78),mcd->name,24);
-#elif PACKETVER < 20180704
-	len = 80 + (int)strlen(mcd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9ff;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13) =mcd->speed;
-	WBUFW(buf,15)=mcd->sc.opt1;
-	WBUFW(buf,17)=mcd->sc.opt2;
-	WBUFL(buf,19)=mcd->sc.option;
-	WBUFW(buf,23)=mcd->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,53)=mcd->sc.opt3;
-	WBUFPOS(buf,59,mcd->bl.x,mcd->bl.y,mcd->dir);
-	WBUFLV(buf,65,status_get_lv(&mcd->bl),mcd->view_class);
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	WBUFW(buf,78) = 0;
-	strncpy(WBUFP(buf,80),mcd->name,24);
-#else
-	len = 84 + (int)strlen(mcd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9ff;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13) =mcd->speed;
-	WBUFW(buf,15)=mcd->sc.opt1;
-	WBUFW(buf,17)=mcd->sc.opt2;
-	WBUFL(buf,19)=mcd->sc.option;
-	WBUFW(buf,23)=mcd->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,57)=mcd->sc.opt3;
-	WBUFPOS(buf,63,mcd->bl.x,mcd->bl.y,mcd->dir);
-	WBUFLV(buf,69,status_get_lv(&mcd->bl),mcd->view_class);
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFL(buf,77) = 0xffffffff;
-	WBUFB(buf,81) = 0;
-	WBUFW(buf,82) = 0;
-	strncpy(WBUFP(buf,84),mcd->name,24);
+	memset(&info, 0, sizeof(info));
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME;
+	info.id = mcd->bl.id;
+	info.speed = mcd->speed;
+	info.opt1 = mcd->sc.opt1;
+	info.opt2 = mcd->sc.opt2;
+	info.option = mcd->sc.option;
+	info.opt3 = mcd->sc.opt3;
+	info.view_class = mcd->view_class;
+	info.hair = battle_config.pet0078_hair_id;
+	info.x = mcd->bl.x;
+	info.y = mcd->bl.y;
+	info.dir = (unsigned char)mcd->dir;
+	info.level = status_get_lv(&mcd->bl);
+	info.level_class = mcd->view_class;
+	info.name = mcd->name;
+	info.objecttype = 9;
+#if PACKETVER >= 20110111
+	info.hair = 100;
 #endif
-	return len;
+	return clif_spawn_build78(&info, buf);
 }
 
 /*==========================================
@@ -4536,161 +2458,33 @@ static int clif_merc0078(struct merc_data *mcd,unsigned char *buf)
  */
 static int clif_merc007b(struct merc_data *mcd,unsigned char *buf)
 {
-	int len;
-	unsigned int tick = gettick();
+	struct clif_spawn_info info;
 
 	nullpo_retr(0, mcd);
 
-#if PACKETVER < 20091104
-	len = packet_db[0x7b].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x7b;
-	WBUFL(buf,2) =mcd->bl.id;
-	WBUFW(buf,6) =mcd->speed;
-	WBUFW(buf,8) =mcd->sc.opt1;
-	WBUFW(buf,10)=mcd->sc.opt2;
-	WBUFW(buf,12)=mcd->sc.option;
-	WBUFW(buf,14)=mcd->view_class;
-	WBUFW(buf,16)=battle_config.pet0078_hair_id;
-	WBUFL(buf,22)=tick;
-	WBUFW(buf,46)=mcd->sc.opt3;
-	WBUFPOS2(buf,50,mcd->bl.x,mcd->bl.y,mcd->ud.to_x,mcd->ud.to_y,8,8);
-	WBUFB(buf,56)=0;
-	WBUFB(buf,57)=0;
-	WBUFLV(buf,58,status_get_lv(&mcd->bl),mcd->view_class);
-#elif PACKETVER < 20110111
-	len = 69 + (int)strlen(mcd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x7f7;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFW(buf,9) =mcd->speed;
-	WBUFW(buf,11)=mcd->sc.opt1;
-	WBUFW(buf,13)=mcd->sc.opt2;
-	WBUFL(buf,15)=mcd->sc.option;
-	WBUFW(buf,19)=mcd->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,29)=tick;
-	WBUFL(buf,51)=mcd->sc.opt3;
-	WBUFPOS2(buf,57,mcd->bl.x,mcd->bl.y,mcd->ud.to_x,mcd->ud.to_y,8,8);
-	WBUFLV(buf,65,status_get_lv(&mcd->bl),mcd->view_class);
-	strncpy(WBUFP(buf,69),mcd->name,24);
-#elif PACKETVER < 20120328
-	len = 71 + (int)strlen(mcd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x856;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFW(buf,9) =mcd->speed;
-	WBUFW(buf,11)=mcd->sc.opt1;
-	WBUFW(buf,13)=mcd->sc.opt2;
-	WBUFL(buf,15)=mcd->sc.option;
-	WBUFW(buf,19)=mcd->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,29)=tick;
-	WBUFL(buf,53)=mcd->sc.opt3;
-	WBUFPOS2(buf,59,mcd->bl.x,mcd->bl.y,mcd->ud.to_x,mcd->ud.to_y,8,8);
-	WBUFLV(buf,67,status_get_lv(&mcd->bl),mcd->view_class);
-	strncpy(WBUFP(buf,71),mcd->name,24);
-#elif PACKETVER < 20131223
-	len = 80;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x914;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFW(buf,9) =mcd->speed;
-	WBUFW(buf,11)=mcd->sc.opt1;
-	WBUFW(buf,13)=mcd->sc.opt2;
-	WBUFL(buf,15)=mcd->sc.option;
-	WBUFW(buf,19)=mcd->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,29)=tick;
-	WBUFL(buf,53)=mcd->sc.opt3;
-	WBUFPOS2(buf,59,mcd->bl.x,mcd->bl.y,mcd->ud.to_x,mcd->ud.to_y,8,8);
-	WBUFLV(buf,67,status_get_lv(&mcd->bl),mcd->view_class);
-	WBUFL(buf,71) = 0xffffffff;
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFB(buf,79) = 0;
-#elif PACKETVER < 20150513
-	len = 84 + (int)strlen(mcd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9db;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13)=mcd->speed;
-	WBUFW(buf,15)=mcd->sc.opt1;
-	WBUFW(buf,17)=mcd->sc.opt2;
-	WBUFL(buf,19)=mcd->sc.option;
-	WBUFW(buf,23)=mcd->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,33)=tick;
-	WBUFL(buf,57)=mcd->sc.opt3;
-	WBUFPOS2(buf,63,mcd->bl.x,mcd->bl.y,mcd->ud.to_x,mcd->ud.to_y,8,8);
-	WBUFLV(buf,71,status_get_lv(&mcd->bl),mcd->view_class);
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	strncpy(WBUFP(buf,84),mcd->name,24);
-#elif PACKETVER < 20180704
-	len = 86 + (int)strlen(mcd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9fd;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13)=mcd->speed;
-	WBUFW(buf,15)=mcd->sc.opt1;
-	WBUFW(buf,17)=mcd->sc.opt2;
-	WBUFL(buf,19)=mcd->sc.option;
-	WBUFW(buf,23)=mcd->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,33)=tick;
-	WBUFL(buf,57)=mcd->sc.opt3;
-	WBUFPOS2(buf,63,mcd->bl.x,mcd->bl.y,mcd->ud.to_x,mcd->ud.to_y,8,8);
-	WBUFLV(buf,71,status_get_lv(&mcd->bl),mcd->view_class);
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	WBUFW(buf,84) = 0;
-	strncpy(WBUFP(buf,86),mcd->name,24);
-#else
-	len = 90 + (int)strlen(mcd->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9fd;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =9;
-	WBUFL(buf,5) =mcd->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13)=mcd->speed;
-	WBUFW(buf,15)=mcd->sc.opt1;
-	WBUFW(buf,17)=mcd->sc.opt2;
-	WBUFL(buf,19)=mcd->sc.option;
-	WBUFW(buf,23)=mcd->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,33)=tick;
-	WBUFL(buf,61)=mcd->sc.opt3;
-	WBUFPOS2(buf,67,mcd->bl.x,mcd->bl.y,mcd->ud.to_x,mcd->ud.to_y,8,8);
-	WBUFLV(buf,75,status_get_lv(&mcd->bl),mcd->view_class);
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFL(buf,83) = 0xffffffff;
-	WBUFB(buf,87) = 0;
-	WBUFW(buf,88) = 0;
-	strncpy(WBUFP(buf,90),mcd->name,24);
+	memset(&info, 0, sizeof(info));
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME | CLIF_SPAWN_F_MERC_TICK33;
+	info.id = mcd->bl.id;
+	info.speed = mcd->speed;
+	info.opt1 = mcd->sc.opt1;
+	info.opt2 = mcd->sc.opt2;
+	info.option = mcd->sc.option;
+	info.opt3 = mcd->sc.opt3;
+	info.view_class = mcd->view_class;
+	info.hair = battle_config.pet0078_hair_id;
+	info.x = mcd->bl.x;
+	info.y = mcd->bl.y;
+	info.to_x = mcd->ud.to_x;
+	info.to_y = mcd->ud.to_y;
+	info.level = status_get_lv(&mcd->bl);
+	info.level_class = mcd->view_class;
+	info.name = mcd->name;
+	info.objecttype = 9;
+#if PACKETVER >= 20110111
+	info.hair = 100;
 #endif
-	return len;
+	return clif_spawn_build7b(&info, buf);
 }
 
 /*==========================================
@@ -4699,173 +2493,32 @@ static int clif_merc007b(struct merc_data *mcd,unsigned char *buf)
  */
 static int clif_elem0078(struct elem_data *eld,unsigned char *buf)
 {
-	int len;
+	struct clif_spawn_info info;
 
 	nullpo_retr(0, eld);
 
-#if PACKETVER < 20071106
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x78;
-	WBUFL(buf,2) =eld->bl.id;
-	WBUFW(buf,6) =eld->speed;
-	WBUFW(buf,8) =eld->sc.opt1;
-	WBUFW(buf,10)=eld->sc.opt2;
-	WBUFW(buf,12)=eld->sc.option;
-	WBUFW(buf,14)=eld->view_class;
-	WBUFW(buf,16)=battle_config.pet0078_hair_id;
-	WBUFW(buf,20)=0;
-	WBUFW(buf,42)=eld->sc.opt3;
-	WBUFPOS(buf,46,eld->bl.x,eld->bl.y,eld->dir);
-	WBUFB(buf,49)=0;
-	WBUFB(buf,50)=0;
-	WBUFLV(buf,52,status_get_lv(&eld->bl),eld->view_class);
-#elif PACKETVER < 20091104
-	len = packet_db[0x78].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x78;
-	WBUFB(buf,2) =10;
-	WBUFL(buf,3) =eld->bl.id;
-	WBUFW(buf,7) =eld->speed;
-	WBUFW(buf,9) =eld->sc.opt1;
-	WBUFW(buf,11)=eld->sc.opt2;
-	WBUFW(buf,13)=eld->sc.option;
-	WBUFW(buf,15)=eld->view_class;
-	WBUFW(buf,17)=battle_config.pet0078_hair_id;
-	WBUFW(buf,21)=0;
-	WBUFW(buf,43)=eld->sc.opt3;
-	WBUFPOS(buf,47,eld->bl.x,eld->bl.y,eld->dir);
-	WBUFB(buf,50)=0;
-	WBUFB(buf,51)=0;
-	WBUFLV(buf,53,status_get_lv(&eld->bl),eld->view_class);
-#elif PACKETVER < 20110111
-	len = 63 + (int)strlen(eld->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x7f9;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFW(buf,9) =eld->speed;
-	WBUFW(buf,11)=eld->sc.opt1;
-	WBUFW(buf,13)=eld->sc.opt2;
-	WBUFL(buf,15)=eld->sc.option;
-	WBUFW(buf,19)=eld->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,47)=eld->sc.opt3;
-	WBUFPOS(buf,53,eld->bl.x,eld->bl.y,eld->dir);
-	WBUFLV(buf,59,status_get_lv(&eld->bl),eld->view_class);
-	strncpy(WBUFP(buf,63),eld->name,24);
-#elif PACKETVER < 20120328
-	len = 65 + (int)strlen(eld->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x857;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFW(buf,9) =eld->speed;
-	WBUFW(buf,11)=eld->sc.opt1;
-	WBUFW(buf,13)=eld->sc.opt2;
-	WBUFL(buf,15)=eld->sc.option;
-	WBUFW(buf,19)=eld->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,49)=eld->sc.opt3;
-	WBUFPOS(buf,55,eld->bl.x,eld->bl.y,eld->dir);
-	WBUFLV(buf,61,status_get_lv(&eld->bl),eld->view_class);
-	strncpy(WBUFP(buf,65),eld->name,24);
-#elif PACKETVER < 20131223
-	len = 74;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x915;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFW(buf,9) =eld->speed;
-	WBUFW(buf,11)=eld->sc.opt1;
-	WBUFW(buf,13)=eld->sc.opt2;
-	WBUFL(buf,15)=eld->sc.option;
-	WBUFW(buf,19)=eld->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,49)=eld->sc.opt3;
-	WBUFPOS(buf,55,eld->bl.x,eld->bl.y,eld->dir);
-	WBUFLV(buf,61,status_get_lv(&eld->bl),eld->view_class);
-	WBUFL(buf,65) = 0xffffffff;
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFB(buf,73) = 0;
-#elif PACKETVER < 20150513
-	len = 78 + (int)strlen(eld->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9dd;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13)=eld->speed;
-	WBUFW(buf,15)=eld->sc.opt1;
-	WBUFW(buf,17)=eld->sc.opt2;
-	WBUFL(buf,19)=eld->sc.option;
-	WBUFW(buf,23)=eld->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,53)=eld->sc.opt3;
-	WBUFPOS(buf,59,eld->bl.x,eld->bl.y,eld->dir);
-	WBUFLV(buf,65,status_get_lv(&eld->bl),eld->view_class);
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	strncpy(WBUFP(buf,78),eld->name,24);
-#elif PACKETVER < 20180704
-	len = 80 + (int)strlen(eld->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9ff;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13)=eld->speed;
-	WBUFW(buf,15)=eld->sc.opt1;
-	WBUFW(buf,17)=eld->sc.opt2;
-	WBUFL(buf,19)=eld->sc.option;
-	WBUFW(buf,23)=eld->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,53)=eld->sc.opt3;
-	WBUFPOS(buf,59,eld->bl.x,eld->bl.y,eld->dir);
-	WBUFLV(buf,65,status_get_lv(&eld->bl),eld->view_class);
-	WBUFL(buf,69) = 0xffffffff;
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFB(buf,77) = 0;
-	WBUFW(buf,78) = 0;
-	strncpy(WBUFP(buf,80),eld->name,24);
-#else
-	len = 84 + (int)strlen(eld->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9ff;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13)=eld->speed;
-	WBUFW(buf,15)=eld->sc.opt1;
-	WBUFW(buf,17)=eld->sc.opt2;
-	WBUFL(buf,19)=eld->sc.option;
-	WBUFW(buf,23)=eld->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,57)=eld->sc.opt3;
-	WBUFPOS(buf,63,eld->bl.x,eld->bl.y,eld->dir);
-	WBUFLV(buf,69,status_get_lv(&eld->bl),eld->view_class);
-	WBUFL(buf,73) = 0xffffffff;
-	WBUFL(buf,77) = 0xffffffff;
-	WBUFB(buf,81) = 0;
-	WBUFW(buf,82) = 0;
-	strncpy(WBUFP(buf,84),eld->name,24);
+	memset(&info, 0, sizeof(info));
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME | CLIF_SPAWN_F_TYPE_AT_2;
+	info.id = eld->bl.id;
+	info.speed = eld->speed;
+	info.opt1 = eld->sc.opt1;
+	info.opt2 = eld->sc.opt2;
+	info.option = eld->sc.option;
+	info.opt3 = eld->sc.opt3;
+	info.view_class = eld->view_class;
+	info.hair = battle_config.pet0078_hair_id;
+	info.x = eld->bl.x;
+	info.y = eld->bl.y;
+	info.dir = (unsigned char)eld->dir;
+	info.level = status_get_lv(&eld->bl);
+	info.level_class = eld->view_class;
+	info.name = eld->name;
+	info.objecttype = 10;
+#if PACKETVER >= 20110111
+	info.hair = 100;
 #endif
-	return len;
+	return clif_spawn_build78(&info, buf);
 }
 
 /*==========================================
@@ -4874,163 +2527,34 @@ static int clif_elem0078(struct elem_data *eld,unsigned char *buf)
  */
 static int clif_elem007b(struct elem_data *eld,unsigned char *buf)
 {
-	int len;
-	unsigned int tick = gettick();
+	struct clif_spawn_info info;
 
 	nullpo_retr(0, eld);
 
-#if PACKETVER < 20091104
-	len = packet_db[0x7b].len;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x7b;
-	WBUFL(buf,2) =eld->bl.id;
-	WBUFW(buf,6) =eld->speed;
-	WBUFW(buf,8) =eld->sc.opt1;
-	WBUFW(buf,10)=eld->sc.opt2;
-	WBUFW(buf,12)=eld->sc.option;
-	WBUFW(buf,14)=eld->view_class;
-	WBUFW(buf,16)=battle_config.pet0078_hair_id;
-	WBUFL(buf,22)=tick;
-	WBUFW(buf,46)=eld->sc.opt3;
-	WBUFPOS2(buf,50,eld->bl.x,eld->bl.y,eld->ud.to_x,eld->ud.to_y,8,8);
-	WBUFB(buf,56)=0;
-	WBUFB(buf,57)=0;
-	WBUFLV(buf,58,status_get_lv(&eld->bl),eld->view_class);
-#elif PACKETVER < 20110111
-	len = 69 + (int)strlen(eld->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x7f7;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFW(buf,9) =eld->speed;
-	WBUFW(buf,11)=eld->sc.opt1;
-	WBUFW(buf,13)=eld->sc.opt2;
-	WBUFL(buf,15)=eld->sc.option;
-	WBUFW(buf,19)=eld->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,29)=tick;
-	WBUFL(buf,51)=eld->sc.opt3;
-	WBUFPOS2(buf,57,eld->bl.x,eld->bl.y,eld->ud.to_x,eld->ud.to_y,8,8);
-	WBUFLV(buf,65,status_get_lv(&eld->bl),eld->view_class);
-	strncpy(WBUFP(buf,69),eld->name,24);
-#elif PACKETVER < 20120328
-	len = 71 + (int)strlen(eld->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x856;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFW(buf,9) =eld->speed;
-	WBUFW(buf,11)=eld->sc.opt1;
-	WBUFW(buf,13)=eld->sc.opt2;
-	WBUFL(buf,15)=eld->sc.option;
-	WBUFW(buf,19)=eld->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,29)=tick;
-	WBUFL(buf,53)=eld->sc.opt3;
-	WBUFPOS2(buf,59,eld->bl.x,eld->bl.y,eld->ud.to_x,eld->ud.to_y,8,8);
-	WBUFLV(buf,67,status_get_lv(&eld->bl),eld->view_class);
-	strncpy(WBUFP(buf,71),eld->name,24);
-#elif PACKETVER < 20131223
-	len = 80;
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x914;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFW(buf,9) =eld->speed;
-	WBUFW(buf,11)=eld->sc.opt1;
-	WBUFW(buf,13)=eld->sc.opt2;
-	WBUFL(buf,15)=eld->sc.option;
-	WBUFW(buf,19)=eld->view_class;
-	WBUFW(buf,21)=100;
-	WBUFL(buf,29)=tick;
-	WBUFL(buf,53)=eld->sc.opt3;
-	WBUFPOS2(buf,59,eld->bl.x,eld->bl.y,eld->ud.to_x,eld->ud.to_y,8,8);
-	WBUFLV(buf,67,status_get_lv(&eld->bl),eld->view_class);
-	WBUFL(buf,71) = 0xffffffff;
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFB(buf,79) = 0;
-#elif PACKETVER < 20150513
-	len = 84 + (int)strlen(eld->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9db;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13)=eld->speed;
-	WBUFW(buf,15)=eld->sc.opt1;
-	WBUFW(buf,17)=eld->sc.opt2;
-	WBUFL(buf,19)=eld->sc.option;
-	WBUFW(buf,23)=eld->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,33)=tick;
-	WBUFL(buf,57)=eld->sc.opt3;
-	WBUFPOS2(buf,63,eld->bl.x,eld->bl.y,eld->ud.to_x,eld->ud.to_y,8,8);
-	WBUFLV(buf,71,status_get_lv(&eld->bl),eld->view_class);
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	strncpy(WBUFP(buf,84),eld->name,24);
-#elif PACKETVER < 20180704
-	len = 86 + (int)strlen(eld->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9fd;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13)=eld->speed;
-	WBUFW(buf,15)=eld->sc.opt1;
-	WBUFW(buf,17)=eld->sc.opt2;
-	WBUFL(buf,19)=eld->sc.option;
-	WBUFW(buf,23)=eld->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,33)=tick;
-	WBUFL(buf,57)=eld->sc.opt3;
-	WBUFPOS2(buf,63,eld->bl.x,eld->bl.y,eld->ud.to_x,eld->ud.to_y,8,8);
-	WBUFLV(buf,71,status_get_lv(&eld->bl),eld->view_class);
-	WBUFL(buf,75) = 0xffffffff;
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFB(buf,83) = 0;
-	WBUFW(buf,84) = 0;
-	strncpy(WBUFP(buf,86),eld->name,24);
-#else
-	len = 90 + (int)strlen(eld->name);
-	memset(buf,0,len);
-
-	WBUFW(buf,0) =0x9fd;
-	WBUFW(buf,2) =(unsigned short)len;
-	WBUFB(buf,4) =10;
-	WBUFL(buf,5) =eld->bl.id;
-	WBUFL(buf,9) =0;
-	WBUFW(buf,13)=eld->speed;
-	WBUFW(buf,15)=eld->sc.opt1;
-	WBUFW(buf,17)=eld->sc.opt2;
-	WBUFL(buf,19)=eld->sc.option;
-	WBUFW(buf,23)=eld->view_class;
-	WBUFW(buf,25)=100;
-	WBUFL(buf,37)=tick;
-	WBUFL(buf,61)=eld->sc.opt3;
-	WBUFPOS2(buf,67,eld->bl.x,eld->bl.y,eld->ud.to_x,eld->ud.to_y,8,8);
-	WBUFLV(buf,75,status_get_lv(&eld->bl),eld->view_class);
-	WBUFL(buf,79) = 0xffffffff;
-	WBUFL(buf,83) = 0xffffffff;
-	WBUFB(buf,87) = 0;
-	WBUFW(buf,88) = 0;
-	strncpy(WBUFP(buf,90),eld->name,24);
+	memset(&info, 0, sizeof(info));
+	info.packet_style = CLIF_SPAWN_STYLE_UNIT;
+	info.flags = CLIF_SPAWN_F_MEMSET | CLIF_SPAWN_F_WRITE_NAME;
+	info.id = eld->bl.id;
+	info.speed = eld->speed;
+	info.opt1 = eld->sc.opt1;
+	info.opt2 = eld->sc.opt2;
+	info.option = eld->sc.option;
+	info.opt3 = eld->sc.opt3;
+	info.view_class = eld->view_class;
+	info.hair = battle_config.pet0078_hair_id;
+	info.x = eld->bl.x;
+	info.y = eld->bl.y;
+	info.to_x = eld->ud.to_x;
+	info.to_y = eld->ud.to_y;
+	info.level = status_get_lv(&eld->bl);
+	info.level_class = eld->view_class;
+	info.name = eld->name;
+	info.objecttype = 10;
+#if PACKETVER >= 20110111
+	info.hair = 100;
 #endif
-	return len;
+	return clif_spawn_build7b(&info, buf);
 }
-
 /*==========================================
  *
  *------------------------------------------

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -764,6 +764,7 @@ enum {
 #define CLIF_SPAWN_F_TYPE_AT_2    0x40 /* write objecttype at buf[2] (elem old) */
 #define CLIF_SPAWN_F_NPC_PCVIEW   0x80 /* npc pcview appearance fields */
 #define CLIF_SPAWN_F_MERC_TICK33  0x100 /* merc007b >=20180704 tick@33 quirk */
+#define CLIF_SPAWN_F_SKIP_LEVEL   0x200 /* npc old 0078: no level field */
 
 struct clif_spawn_info {
 	int packet_style;
@@ -904,7 +905,8 @@ static int clif_spawn_build78(const struct clif_spawn_info *info, unsigned char 
 		WBUFPOS(buf,46,info->x,info->y,info->dir);
 		WBUFB(buf,49)=info->xsize;
 		WBUFB(buf,50)=info->ysize;
-		clif_spawn_write_level(buf,52,info);
+		if(!(info->flags & CLIF_SPAWN_F_SKIP_LEVEL))
+			clif_spawn_write_level(buf,52,info);
 		clif_spawn_npc_guild78(buf, info);
 		return len;
 #elif PACKETVER < 20091104
@@ -935,10 +937,12 @@ static int clif_spawn_build78(const struct clif_spawn_info *info, unsigned char 
 		WBUFB(buf,50)=info->xsize;
 		WBUFB(buf,51)=info->ysize;
 		/* mob non-pcview keeps LV at 52; others use 53 */
-		if(info->flags & CLIF_SPAWN_F_EMP_GUILD)
-			clif_spawn_write_level(buf,52,info);
-		else
-			clif_spawn_write_level(buf,53,info);
+		if(!(info->flags & CLIF_SPAWN_F_SKIP_LEVEL)) {
+			if(info->flags & CLIF_SPAWN_F_EMP_GUILD)
+				clif_spawn_write_level(buf,52,info);
+			else
+				clif_spawn_write_level(buf,53,info);
+		}
 		clif_spawn_npc_guild78(buf, info);
 		return len;
 #endif
@@ -2147,9 +2151,11 @@ static int clif_npc0078(struct npc_data *nd,unsigned char *buf,struct map_sessio
 	info.name = nd->name;
 	info.objecttype = (nd->u.scr.moveable > 0) ? 12 : 6;
 #if PACKETVER < 20091104
+	info.flags |= CLIF_SPAWN_F_SKIP_LEVEL;
 	info.xsize = 5;
 	info.ysize = 5;
 #endif
+#if PACKETVER >= 20091104
 	if(npc_is_pcview(nd)) {
 		info.flags |= CLIF_SPAWN_F_NPC_PCVIEW;
 		info.hair = nd->hair;
@@ -2162,6 +2168,7 @@ static int clif_npc0078(struct npc_data *nd,unsigned char *buf,struct map_sessio
 		info.sex = nd->sex;
 		info.style = nd->style;
 	}
+#endif
 	if( nd->subtype != WARP &&
 	    nd->class_ == WARP_DEBUG_CLASS &&
 	    nd->u.scr.guild_id > 0 &&


### PR DESCRIPTION
## Summary
- Issue #55 の第1段階として、`clif_set0078` / `007b` および mob/npc/pet/hom/merc/elem の同型組み立てを `struct clif_spawn_info` + `clif_spawn_build78` / `clif_spawn_build7b` に統合した
- 既存の呼び出し側シグネチャは維持し、PACKETVER 分岐とエンティティ固有 quirk（cloaking、EMP guild、名前非コピー等）はビルダー／充填側で保全した
- 旧 PACKETVER 向けに `CLIF_SPAWN_F_SKIP_LEVEL` と NPC pcview 充填ゲートを追加し、master の `clif_npc0078` 互換（レベル未書き込み・外見未書き込み）を復元した
- ファイル分割やアイテムリスト共通化は含めていない（後続作業）

## Test plan
- [x] `PACKETVER=20151029` で map-server がビルドできること（CI 通過）
- [ ] PC / Mob / NPC / Pet / Hom / Merc / Elem の出現・移動表示が従来どおりであること
- [x] 変更前後で 0078/007b 系パケットダンプを比較すること（下記 Verification）
- [ ] `clif.c` の日本語コメントが Shift_JIS のまま読めること

## Verification（パケットダンプ比較）

master と本ブランチから実際の `clif_*0078` / `007b` を抽出し、同一フィクスチャ・固定 `gettick` でオフライン生成した hex dump を比較した。

| PACKETVER | 結果 |
|-----------|------|
| 20151029（デフォルト） | **IDENTICAL** |
| 20071106（旧クライアント） | **IDENTICAL** |

比較ケース（各 PACKETVER）:
- PC / Mob / Mob(pcview) / NPC / NPC(pcview) / Pet / Hom / Merc / Elem の standing(0078) と walking(007b)

Fixes #55