### PR TITLE
CHANGELOG: PR #65（0078/007b スパウンパケット共通化）を追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ----------------------------------------
+//1600 [2026/08/09] by Cocoa
+
+・0078/007b スパウンパケット組み立ての共通化（clif.c）
+	・PC / Mob / NPC / Pet / Hom / Merc / Elem 向けの同型組み立てを struct clif_spawn_info と clif_spawn_build78 / clif_spawn_build7b に統合
+	・呼び出し側シグネチャは維持し、PACKETVER 分岐とエンティティ固有 quirk（cloaking、EMP guild、名前非コピー等）を保全
+	・旧 PACKETVER 向けに CLIF_SPAWN_F_SKIP_LEVEL と NPC pcview 充填ゲートを追加し、NPC 0078 互換（レベル未書き込み・外見未書き込み）を復元
+詳細はPR（https://github.com/auriga/auriga/pull/65）を参照
+
+----------------------------------------
 //1599 [2026/08/03] by Cocoa
 
 ・Visual Studio 対応の整理


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- マージ済みの [#65](https://github.com/auriga/auriga/pull/65)（`clif.c` の 0078/007b スパウンパケット共通化）の内容を `CHANGELOG.md` に `//1600` として追記しました。
- Issue #55 第1段階として、`struct clif_spawn_info` / `clif_spawn_build78` / `clif_spawn_build7b` への統合と旧 PACKETVER 向け互換復元を記載しています。

## Test plan
- [x] `CHANGELOG.md` 先頭が `//1600` で、続く番号が `//1599` であること
- [x] 記載内容が PR #65 の Summary と一致すること

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd5b5a15-426c-4d59-b32f-f64cf6c9a32a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd5b5a15-426c-4d59-b32f-f64cf6c9a32a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

