### PR TITLE
【Patch 1604】refactor(script): split map buildins into buildin_map.c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ----------------------------------------
+//1604 [2026/08/09] by Cocoa
+
+・script.c のビルドイン命令分割（第1弾）: map 系命令（warp / announce / mapflag / pvp・gvg 等）を buildin_map.c へ分離。共有ヘルパーを script_internal.h 経由で公開（挙動変更なし）（script.c, buildin_map.c, script_internal.h, map-server.vcxproj）
+----------------------------------------
 //1603 [2026/08/09] by Cocoa
 
 ・skill.c の巨大 switch 分割（第3弾）: skill_check_condition2_pc / skill_unit_onplace_timer / skill_readdb をそれぞれ skill_check_condition.c / skill_unit_onplace.c / skill_readdb.c へ分離（挙動変更なし）（skill.c, skill_check_condition.c, skill_unit_onplace.c, skill_readdb.c, skill_internal.h, map-server.vcxproj）

--- a/src/map/buildin_map.c
+++ b/src/map/buildin_map.c
@@ -1,0 +1,845 @@
+/*
+ * Copyright (C) 2002-2020  Auriga
+ *
+ * This file is part of Auriga.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#include "db.h"
+#include "socket.h"
+#include "timer.h"
+#include "malloc.h"
+#include "mmo.h"
+#include "nullpo.h"
+#include "utils.h"
+
+#include "map.h"
+#include "guild.h"
+#include "clif.h"
+#include "itemdb.h"
+#include "pc.h"
+#include "script.h"
+#include "script_internal.h"
+#include "mob.h"
+#include "npc.h"
+#include "intif.h"
+#include "battle.h"
+#include "unit.h"
+
+/* Split from script.c (Issue #61) */
+
+/*==========================================
+ *
+ *------------------------------------------
+ */
+int script_warp(struct map_session_data *sd, const char *mapname, int x, int y)
+{
+	nullpo_retr(0, sd);
+
+	if(strcmp(mapname, "Random") == 0) {
+		pc_randomwarp(sd, 3);
+	} else if(strcmp(mapname, "SavePoint") == 0) {
+		pc_setpos(sd, sd->status.save_point.map, sd->status.save_point.x, sd->status.save_point.y, 3);
+	} else {
+		if(pc_setpos(sd, mapname, x, y, 0)) {
+			// 失敗したので .gat を付けてリトライ
+			char *str = (char *)aMalloc(strlen(mapname) + 5);
+			memcpy(str, mapname, strlen(mapname) + 1);
+			strcat(str, ".gat");
+			pc_setpos(sd, str, x, y, 0);
+			aFree(str);
+		}
+	}
+
+	if(unit_isdead(&sd->bl)) {
+		pc_setstand(sd);
+		pc_setrestartvalue(sd, 3);
+	}
+
+	return 0;
+}
+
+/*==========================================
+ *
+ *------------------------------------------
+ */
+int buildin_warp(struct script_state *st)
+{
+	int x,y;
+	char *str;
+	struct block_list *bl = map_id2bl(st->rid);
+
+	nullpo_retr(0, bl);
+
+	str=conv_str(st,& (st->stack->stack_data[st->start+2]));
+	x=conv_num(st,& (st->stack->stack_data[st->start+3]));
+	y=conv_num(st,& (st->stack->stack_data[st->start+4]));
+
+	if(bl->type == BL_PC) {
+		script_warp((struct map_session_data *)bl, str, x, y);
+	} else if(bl->type == BL_MOB) {
+		struct mob_data *md = (struct mob_data *)bl;
+
+		if(strcmp(str, "Random") == 0) {
+			mob_warp(md, -1, -1, -1, 3);
+		} else {
+			int m = map_mapname2mapid(str);
+			if(m >= 0)
+				mob_warp(md, m, x, y, 3);
+		}
+	}
+	return 0;
+}
+
+/*==========================================
+ * MAP指定ワープ
+ *------------------------------------------
+ */
+static int buildin_mapwarp_sub(struct block_list *bl,va_list ap)
+{
+	int x,y;
+	char *mapname;
+	struct map_session_data *sd;
+
+	nullpo_retr(0, bl);
+	nullpo_retr(0, sd = (struct map_session_data *)bl);
+
+	mapname = va_arg(ap, char *);
+	x = va_arg(ap,int);
+	y = va_arg(ap,int);
+
+	script_warp(sd, mapname, x, y);
+
+	return 0;
+}
+
+int buildin_mapwarp(struct script_state *st)
+{
+	int x,y,m;
+	char *mapname, *str;
+
+	mapname=conv_str(st,& (st->stack->stack_data[st->start+2]));
+	str=conv_str(st,& (st->stack->stack_data[st->start+3]));
+	x=conv_num(st,& (st->stack->stack_data[st->start+4]));
+	y=conv_num(st,& (st->stack->stack_data[st->start+5]));
+
+	m = script_mapname2mapid(st,mapname);
+	if(m >= 0)
+		map_foreachinarea(buildin_mapwarp_sub,m,0,0,map[m].xs,map[m].ys,BL_PC,str,x,y);
+	return 0;
+}
+
+/*==========================================
+ * エリア指定ワープ
+ *------------------------------------------
+ */
+int buildin_areawarp(struct script_state *st)
+{
+	int x,y,m;
+	char *mapname, *str;
+	int x0,y0,x1,y1;
+
+	mapname=conv_str(st,& (st->stack->stack_data[st->start+2]));
+	x0=conv_num(st,& (st->stack->stack_data[st->start+3]));
+	y0=conv_num(st,& (st->stack->stack_data[st->start+4]));
+	x1=conv_num(st,& (st->stack->stack_data[st->start+5]));
+	y1=conv_num(st,& (st->stack->stack_data[st->start+6]));
+	str=conv_str(st,& (st->stack->stack_data[st->start+7]));
+	x=conv_num(st,& (st->stack->stack_data[st->start+8]));
+	y=conv_num(st,& (st->stack->stack_data[st->start+9]));
+
+	m = script_mapname2mapid(st,mapname);
+	if(m >= 0)
+		map_foreachinarea(buildin_mapwarp_sub,m,x0,y0,x1,y1,BL_PC,str,x,y);
+	return 0;
+}
+
+/*==========================================
+ * セーブポイントの保存
+ *------------------------------------------
+ */
+int buildin_savepoint(struct script_state *st)
+{
+	int x,y;
+	char *str;
+
+	str=conv_str(st,& (st->stack->stack_data[st->start+2]));
+	x=conv_num(st,& (st->stack->stack_data[st->start+3]));
+	y=conv_num(st,& (st->stack->stack_data[st->start+4]));
+	pc_setsavepoint(script_rid2sd(st),str,x,y);
+	return 0;
+}
+
+/*==========================================
+ * 天の声アナウンス
+ *------------------------------------------
+ */
+int buildin_announce(struct script_state *st)
+{
+	char *str = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	int flag  = conv_num(st,& (st->stack->stack_data[st->start+3]));
+	size_t len;
+	int color = 0;
+	int type = 400;
+	int size = 12;
+	int align = 0;
+	int pos_y = 0;
+
+	if(st->end > st->start+4)
+		color = conv_num(st,& (st->stack->stack_data[st->start+4]));
+	if(st->end > st->start+5)
+		type = conv_num(st,& (st->stack->stack_data[st->start+5]));
+	if(st->end > st->start+6)
+		size = conv_num(st,& (st->stack->stack_data[st->start+6]));
+	if(st->end > st->start+7)
+		align = conv_num(st,& (st->stack->stack_data[st->start+7]));
+	if(st->end > st->start+8)
+		pos_y = conv_num(st,& (st->stack->stack_data[st->start+8]));
+
+	len = strlen(str)+1;
+
+	if(flag&0x07) {
+		struct block_list *bl = NULL;
+		if(flag&0x08) {
+			bl = map_id2bl(st->oid);
+		} else {
+			struct map_session_data *sd = script_rid2sd(st);
+			if(sd)
+				bl = &sd->bl;
+		}
+		if(bl == NULL)
+			return 0;
+
+		if(color)
+			clif_announce(bl,str,len,(unsigned int)color,type,size,align,pos_y,flag);
+		else
+			clif_GMmessage(bl,str,len,flag);
+	} else {
+		if(color)
+			intif_announce(str,len,(unsigned int)color,type,size,align,pos_y);
+		else
+			intif_GMmessage(str,len,flag);
+	}
+	return 0;
+}
+
+/*==========================================
+ * 天の声アナウンス（特定マップ）
+ *------------------------------------------
+ */
+static int buildin_mapannounce_sub(struct block_list *bl,va_list ap)
+{
+	char *str;
+	size_t len;
+	int color;
+	int flag;
+	int type,size,align,pos_y;
+
+	nullpo_retr(0, bl);
+
+	str   = va_arg(ap,char *);
+	len   = va_arg(ap,size_t);
+	flag  = va_arg(ap,int);
+	color = va_arg(ap,int);
+	type  = va_arg(ap,int);
+	size  = va_arg(ap,int);
+	align = va_arg(ap,int);
+	pos_y = va_arg(ap,int);
+
+	if(color)
+		clif_announce(bl,str,len,(unsigned int)color,type,size,align,pos_y,flag|3);
+	else
+		clif_GMmessage(bl,str,len,flag|3);
+	return 0;
+}
+
+int buildin_mapannounce(struct script_state *st)
+{
+	char *mapname,*str;
+	int color = 0;
+	int flag,m;
+	int type = 400;
+	int size = 12;
+	int align = 0;
+	int pos_y = 0;
+
+	mapname=conv_str(st,& (st->stack->stack_data[st->start+2]));
+	str=conv_str(st,& (st->stack->stack_data[st->start+3]));
+	flag=conv_num(st,& (st->stack->stack_data[st->start+4]));
+	if (st->end>st->start+5)
+		color=conv_num(st,& (st->stack->stack_data[st->start+5]));
+	if (st->end>st->start+6)
+		type=conv_num(st,& (st->stack->stack_data[st->start+6]));
+	if (st->end>st->start+7)
+		size=conv_num(st,& (st->stack->stack_data[st->start+7]));
+	if (st->end>st->start+8)
+		align=conv_num(st,& (st->stack->stack_data[st->start+8]));
+	if (st->end>st->start+9)
+		pos_y=conv_num(st,& (st->stack->stack_data[st->start+9]));
+
+	m = script_mapname2mapid(st,mapname);
+	if(m >= 0)
+		map_foreachinarea(buildin_mapannounce_sub,m,0,0,map[m].xs,map[m].ys,BL_PC,str,strlen(str)+1,flag&0x10,color,type,size,align,pos_y);
+	return 0;
+}
+
+/*==========================================
+ * 天の声アナウンス（特定エリア）
+ *------------------------------------------
+ */
+int buildin_areaannounce(struct script_state *st)
+{
+	char *mapname,*str;
+	int flag,m;
+	int x0,y0,x1,y1;
+	int color = 0;
+	int type = 400;
+	int size = 12;
+	int align = 0;
+	int pos_y = 0;
+
+	mapname = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	x0      = conv_num(st,& (st->stack->stack_data[st->start+3]));
+	y0      = conv_num(st,& (st->stack->stack_data[st->start+4]));
+	x1      = conv_num(st,& (st->stack->stack_data[st->start+5]));
+	y1      = conv_num(st,& (st->stack->stack_data[st->start+6]));
+	str     = conv_str(st,& (st->stack->stack_data[st->start+7]));
+	flag    = conv_num(st,& (st->stack->stack_data[st->start+8]));
+	if (st->end>st->start+9)
+		color = conv_num(st,& (st->stack->stack_data[st->start+9]));
+	if (st->end>st->start+10)
+		type = conv_num(st,& (st->stack->stack_data[st->start+10]));
+	if (st->end>st->start+11)
+		size = conv_num(st,& (st->stack->stack_data[st->start+11]));
+	if (st->end>st->start+12)
+		align = conv_num(st,& (st->stack->stack_data[st->start+12]));
+	if (st->end>st->start+13)
+		pos_y = conv_num(st,& (st->stack->stack_data[st->start+13]));
+
+	m = script_mapname2mapid(st,mapname);
+	if(m >= 0)
+		map_foreachinarea(buildin_mapannounce_sub,m,x0,y0,x1,y1,BL_PC,str,strlen(str)+1,flag&0x10,color,type,size,align,pos_y);
+	return 0;
+}
+
+/*==========================================
+ * ユーザー数取得
+ *------------------------------------------
+ */
+int buildin_getusers(struct script_state *st)
+{
+	int flag=conv_num(st,& (st->stack->stack_data[st->start+2]));
+	int val = -1;
+
+	switch(flag&0x07){
+		case 0:
+		{
+			struct block_list *bl=map_id2bl( (flag&0x08)? st->oid: st->rid );
+			if(bl)
+				val=map[bl->m].users;
+			break;
+		}
+		case 1:
+			val=map_getusers();
+			break;
+	}
+	push_val(st->stack,C_INT,val);
+	return 0;
+}
+
+/*==========================================
+ * 繋いでるユーザーの全員の名前取得
+ *------------------------------------------
+ */
+int buildin_getusersname(struct script_state *st)
+{
+	struct map_session_data *sd = script_rid2sd(st);
+	struct map_session_data *pl_sd = NULL;
+	int i=0,disp_num=1;
+
+	nullpo_retr(0, sd);
+
+	for (i=0;i<fd_max;i++) {
+		if(session[i] && (pl_sd = (struct map_session_data *)session[i]->session_data) && pl_sd->state.auth){
+			if( !(battle_config.hide_GM_session && pc_isGM(pl_sd)) ){
+				if((disp_num++)%10==0)
+					clif_scriptnext(sd,st->oid);
+				clif_scriptmes(sd,st->oid,pl_sd->status.name);
+			}
+		}
+	}
+	return 0;
+}
+
+/*==========================================
+ * マップ指定ユーザー数取得
+ *------------------------------------------
+ */
+int buildin_getmapusers(struct script_state *st)
+{
+	char *str;
+	int m;
+
+	str=conv_str(st,& (st->stack->stack_data[st->start+2]));
+
+	m = script_mapname2mapid(st,str);
+	if(m < 0)
+		push_val(st->stack,C_INT,-1);
+	else
+		push_val(st->stack,C_INT,map[m].users);
+	return 0;
+}
+
+/*==========================================
+ * エリア指定ユーザー数取得
+ *------------------------------------------
+ */
+static int buildin_getareausers_sub(struct block_list *bl,va_list ap)
+{
+	return 1;
+}
+
+int buildin_getareausers(struct script_state *st)
+{
+	char *str;
+	int m,x0,y0,x1,y1,users=0;
+
+	str=conv_str(st,& (st->stack->stack_data[st->start+2]));
+	x0=conv_num(st,& (st->stack->stack_data[st->start+3]));
+	y0=conv_num(st,& (st->stack->stack_data[st->start+4]));
+	x1=conv_num(st,& (st->stack->stack_data[st->start+5]));
+	y1=conv_num(st,& (st->stack->stack_data[st->start+6]));
+
+	m = script_mapname2mapid(st,str);
+	if(m < 0) {
+		push_val(st->stack,C_INT,-1);
+		return 0;
+	}
+	users = map_foreachinarea(buildin_getareausers_sub,m,x0,y0,x1,y1,BL_PC);
+	push_val(st->stack,C_INT,users);
+	return 0;
+}
+
+/*==========================================
+ * エリア指定ドロップアイテム数取得
+ *------------------------------------------
+ */
+static int buildin_getareadropitem_sub(struct block_list *bl,va_list ap)
+{
+	int item=va_arg(ap,int);
+	struct flooritem_data *fitem;
+
+	nullpo_retr(0, bl);
+	nullpo_retr(0, fitem = (struct flooritem_data *)bl);
+
+	if(fitem->item_data.nameid == item)
+		return fitem->item_data.amount;
+
+	return 0;
+}
+
+int buildin_getareadropitem(struct script_state *st)
+{
+	char *str;
+	int m,x0,y0,x1,y1,item=0,amount=0;
+	struct script_data *data;
+
+	str = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	x0  = conv_num(st,& (st->stack->stack_data[st->start+3]));
+	y0  = conv_num(st,& (st->stack->stack_data[st->start+4]));
+	x1  = conv_num(st,& (st->stack->stack_data[st->start+5]));
+	y1  = conv_num(st,& (st->stack->stack_data[st->start+6]));
+
+	data = &(st->stack->stack_data[st->start+7]);
+	get_val(st,data);
+	if( isstr(data) ) {
+		const char *name = conv_str(st,data);
+		struct item_data *item_data = itemdb_searchname(name);
+		if(item_data)
+			item = item_data->nameid;
+	} else {
+		item = conv_num(st,data);
+	}
+
+	m = script_mapname2mapid(st,str);
+	if(m < 0) {
+		push_val(st->stack,C_INT,-1);
+		return 0;
+	}
+	if(item > 0) {
+		amount = map_foreachinarea(buildin_getareadropitem_sub,m,x0,y0,x1,y1,BL_ITEM,item);
+	}
+	push_val(st->stack,C_INT,amount);
+
+	return 0;
+}
+
+/*==========================================
+ * マップフラグのindexからアドレスを返す
+ *------------------------------------------
+ */
+static int* script_conv_mapflag(int m,int type)
+{
+	if(m < 0)
+		return NULL;
+
+	switch(type) {
+		case MF_NOSAVE:             return &map[m].flag.nosave;
+		case MF_NOMEMO:             return &map[m].flag.nomemo;
+		case MF_NOTELEPORT:         return &map[m].flag.noteleport;
+		case MF_NOPORTAL:           return &map[m].flag.noportal;
+		case MF_NORETURN:           return &map[m].flag.noreturn;
+		case MF_MONSTER_NOTELEPORT: return &map[m].flag.monster_noteleport;
+		case MF_NOBRANCH:           return &map[m].flag.nobranch;
+		case MF_NOPENALTY:          return &map[m].flag.nopenalty;
+		case MF_PVP:                return &map[m].flag.pvp;
+		case MF_PVP_NOPARTY:        return &map[m].flag.pvp_noparty;
+		case MF_PVP_NOGUILD:        return &map[m].flag.pvp_noguild;
+		case MF_PVP_NIGHTMAREDROP:  return &map[m].flag.pvp_nightmaredrop;
+		case MF_PVP_NOCALCRANK:     return &map[m].flag.pvp_nocalcrank;
+		case MF_GVG:                return &map[m].flag.gvg;
+		case MF_GVG_NOPARTY:        return &map[m].flag.gvg_noparty;
+		case MF_GVG_NIGHTMAREDROP:  return &map[m].flag.gvg_nightmaredrop;
+		case MF_NOZENYPENALTY:      return &map[m].flag.nozenypenalty;
+		case MF_NOTRADE:            return &map[m].flag.notrade;
+		case MF_NOSKILL:            return &map[m].flag.noskill;
+		case MF_NOABRA:             return &map[m].flag.noabra;
+		case MF_NODROP:             return &map[m].flag.nodrop;
+		case MF_SNOW:               return &map[m].flag.snow;
+		case MF_FOG:                return &map[m].flag.fog;
+		case MF_SAKURA:             return &map[m].flag.sakura;
+		case MF_LEAVES:             return &map[m].flag.leaves;
+		case MF_RAIN:               return &map[m].flag.rain;
+		case MF_FIREWORKS:          return &map[m].flag.fireworks;
+		case MF_CLOUD1:             return &map[m].flag.cloud1;
+		case MF_CLOUD2:             return &map[m].flag.cloud2;
+		case MF_CLOUD3:             return &map[m].flag.cloud3;
+		case MF_BASEEXP_RATE:       return &map[m].flag.base_exp_rate;
+		case MF_JOBEXP_RATE:        return &map[m].flag.job_exp_rate;
+		case MF_PK:                 return &map[m].flag.pk;
+		case MF_PK_NOPARTY:         return &map[m].flag.pk_noparty;
+		case MF_PK_NOGUILD:         return &map[m].flag.pk_noguild;
+		case MF_PK_NIGHTMAREDROP:   return &map[m].flag.pk_nightmaredrop;
+		case MF_PK_NOCALCRANK:      return &map[m].flag.pk_nocalcrank;
+		case MF_NOICEWALL:          return &map[m].flag.noicewall;
+		case MF_TURBO:              return &map[m].flag.turbo;
+		case MF_NOREVIVE:           return &map[m].flag.norevive;
+		case MF_NOCOMMAND:          return &map[m].flag.nocommand;
+		case MF_NOJUMP:             return &map[m].flag.nojump;
+		case MF_NOCOSTUME:          return &map[m].flag.nocostume;
+		case MF_TOWN:               return &map[m].flag.town;
+		case MF_DAMAGE_RATE:        return &map[m].flag.damage_rate;
+	}
+	return NULL;
+}
+
+/*==========================================
+ * マップフラグを設定する
+ *------------------------------------------
+ */
+int buildin_setmapflag(struct script_state *st)
+{
+	char *mapname = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	int type = conv_num(st,& (st->stack->stack_data[st->start+3]));
+	int m;
+	int *flag;
+
+	if((m = script_mapname2mapid(st,mapname)) < 0)
+		return 0;
+	flag = script_conv_mapflag(m, type);
+
+	if(flag)
+	{
+		*flag = 1;
+		switch (type) {		// 特殊処理が必要なマップフラグ
+		case MF_NOSAVE:
+			if(st->end > st->start+6) {
+				char *str = conv_str(st,& (st->stack->stack_data[st->start+4]));
+				int x     = conv_num(st,& (st->stack->stack_data[st->start+5]));
+				int y     = conv_num(st,& (st->stack->stack_data[st->start+6]));
+				strncpy(map[m].save.map, str, 16);
+				map[m].save.map[15] = '\0';	// force \0 terminal
+				map[m].save.x = x;
+				map[m].save.y = y;
+			}
+			break;
+		case MF_BASEEXP_RATE:
+		case MF_JOBEXP_RATE:
+		case MF_NOCOMMAND:
+		case MF_DAMAGE_RATE:
+			if(st->end > st->start+4) {
+				*flag = conv_num(st,& (st->stack->stack_data[st->start+4]));
+			}
+			break;
+		case MF_PVP_NIGHTMAREDROP:
+		case MF_GVG_NIGHTMAREDROP:
+		case MF_PK_NIGHTMAREDROP:
+			if(st->end > st->start+6) {
+				char buf[128];
+				char *arg1 = conv_str(st,& (st->stack->stack_data[st->start+4]));
+				char *arg2 = conv_str(st,& (st->stack->stack_data[st->start+5]));
+				int  per   = conv_num(st,& (st->stack->stack_data[st->start+6]));
+				snprintf(buf, sizeof(buf), "%s,%s,%d", arg1, arg2, per);
+				npc_set_mapflag_sub(m, buf, type);
+			}
+			break;
+		}
+		map_field_setting();
+	}
+	return 0;
+}
+
+/*==========================================
+ * マップフラグを削除する
+ *------------------------------------------
+ */
+int buildin_removemapflag(struct script_state *st)
+{
+	char *mapname = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	int type = conv_num(st,& (st->stack->stack_data[st->start+3]));
+	int m;
+	int *flag;
+
+	if((m = script_mapname2mapid(st,mapname)) < 0)
+		return 0;
+	flag = script_conv_mapflag(m, type);
+
+	if(flag)
+	{
+		*flag = 0;
+		switch (type) {		// 特殊処理が必要なマップフラグ
+		case MF_PVP_NIGHTMAREDROP:
+		case MF_GVG_NIGHTMAREDROP:
+		case MF_PK_NIGHTMAREDROP:
+			{
+				int i,j;
+				for(i=0; i<MAX_DROP_PER_MAP; i++) {	// 該当のドロップリストを削除して空きを詰める
+					if(map[m].drop_list[i].drop_id == 0)
+						break;
+					if(map[m].drop_list[i].drop_flag != type)
+						continue;
+					for(j=i+1; j<MAX_DROP_PER_MAP && map[m].drop_list[j].drop_id != 0; j++);
+					j--;
+					if(i != j) {
+						memcpy(&map[m].drop_list[i], &map[m].drop_list[j], sizeof(map[m].drop_list[0]));
+					}
+					memset(&map[m].drop_list[j], 0, sizeof(map[m].drop_list[0]));
+					i--;
+				}
+			}
+			break;
+		}
+		map_field_setting();
+	}
+	return 0;
+}
+
+/*==========================================
+ * マップフラグのチェック
+ *------------------------------------------
+ */
+int buildin_checkmapflag(struct script_state *st)
+{
+	char *mapname = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	int type = conv_num(st,& (st->stack->stack_data[st->start+3]));
+	int m;
+	int *flag;
+
+	if((m = script_mapname2mapid(st,mapname)) < 0) {
+		push_val(st->stack,C_INT,-1);
+		return 0;
+	}
+
+	flag = script_conv_mapflag(m ,type);
+
+	push_val(st->stack,C_INT,((flag)? *flag: -1));
+	return 0;
+}
+
+/*==========================================
+ * PvPオン
+ *------------------------------------------
+ */
+int buildin_pvpon(struct script_state *st)
+{
+	char *str;
+	int m;
+
+	str = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	m = script_mapname2mapid(st,str);
+	if(m >= 0 && !map[m].flag.pvp) {
+		int i;
+		struct map_session_data *pl_sd;
+		unsigned int tick = gettick();
+
+		map[m].flag.pvp = 1;
+		clif_send0199(m,1);
+
+		for(i=0; i<fd_max; i++) {	// 人数分ループ
+			if(session[i] && (pl_sd = (struct map_session_data *)session[i]->session_data) && pl_sd->state.auth) {
+				if(m == pl_sd->bl.m && pl_sd->pvp_timer == -1) {
+					pl_sd->pvp_timer = add_timer(tick+200,pc_calc_pvprank_timer,pl_sd->bl.id,NULL);
+					pl_sd->pvp_rank = 0;
+					pl_sd->pvp_lastusers = 0;
+					pl_sd->pvp_point = 5;
+				}
+			}
+		}
+		map_field_setting();
+	}
+	return 0;
+}
+
+/*==========================================
+ * PvPオフ
+ *------------------------------------------
+ */
+int buildin_pvpoff(struct script_state *st)
+{
+	char *str;
+	int m;
+
+	str = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	m = script_mapname2mapid(st,str);
+	if(m >= 0 && map[m].flag.pvp) {
+		int i;
+		struct map_session_data *pl_sd;
+
+		map[m].flag.pvp = 0;
+		clif_send0199(m,0);
+
+		for(i=0; i<fd_max; i++) {	// 人数分ループ
+			if(session[i] && (pl_sd = (struct map_session_data *)session[i]->session_data) && pl_sd->state.auth) {
+				if(m == pl_sd->bl.m) {
+					clif_pvpset(pl_sd,0,0,2);
+					if(pl_sd->pvp_timer != -1) {
+						delete_timer(pl_sd->pvp_timer,pc_calc_pvprank_timer);
+						pl_sd->pvp_timer = -1;
+					}
+				}
+			}
+		}
+		map_field_setting();
+	}
+
+	return 0;
+}
+
+/*==========================================
+ * GvGオン
+ *------------------------------------------
+ */
+int buildin_gvgon(struct script_state *st)
+{
+	char *str;
+	int m;
+
+	str = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	m = script_mapname2mapid(st,str);
+	if(m >= 0 && !map[m].flag.gvg) {
+		map[m].flag.gvg = 1;
+		clif_send0199(m,3);
+		map_field_setting();
+	}
+
+	return 0;
+}
+
+/*==========================================
+ * GvGオフ
+ *------------------------------------------
+ */
+int buildin_gvgoff(struct script_state *st)
+{
+	char *str;
+	int m;
+
+	str = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	m = script_mapname2mapid(st,str);
+	if(m >= 0 && map[m].flag.gvg) {
+		map[m].flag.gvg = 0;
+		clif_send0199(m,0);
+		map_field_setting();
+	}
+
+	return 0;
+}
+
+
+/*==========================================
+ * 特定対象を移動、攻城戦用
+ *------------------------------------------
+ */
+static int buildin_maprespawnguildid_sub_pc(struct map_session_data *sd, va_list ap)
+{
+	int m    = va_arg(ap, int);
+	int g_id = va_arg(ap, int);
+	int flag = va_arg(ap, int);
+
+	nullpo_retr(0, sd);
+
+	if(sd->bl.m == m) {
+		// ワープ中などでブロックリストから外れたPCも対象とするかどうか
+		if(battle_config.maprespawnguildid_all_players || sd->bl.prev) {
+			int match = (g_id > 0 && sd->status.guild_id == g_id);
+			if( (flag&1 && match) || (flag&2 && !match) )
+				pc_setpos(sd, sd->status.save_point.map, sd->status.save_point.x, sd->status.save_point.y, 3);
+		}
+	}
+
+	return 0;
+}
+
+static int buildin_maprespawnguildid_sub_mob(struct block_list *bl, va_list ap)
+{
+	struct mob_data *md = NULL;
+
+	nullpo_retr(0, bl);
+
+	if(bl->type != BL_MOB || (md = (struct mob_data *)bl) == NULL)
+		return 0;
+
+	if(!md->guild_id)
+		unit_remove_map(&md->bl, 1, 0);
+
+	return 0;
+}
+
+int buildin_maprespawnguildid(struct script_state *st)
+{
+	char *mapname = conv_str(st,& (st->stack->stack_data[st->start+2]));
+	int g_id      = conv_num(st,& (st->stack->stack_data[st->start+3]));
+	int flag      = conv_num(st,& (st->stack->stack_data[st->start+4]));
+	int m;
+
+	m = script_mapname2mapid(st,mapname);
+	if(m >= 0) {
+		if(flag&3) {
+			clif_foreachclient(buildin_maprespawnguildid_sub_pc, m, g_id, flag);
+		}
+		if(flag&4) {
+			map_foreachinarea(buildin_maprespawnguildid_sub_mob, m, 0, 0, map[m].xs, map[m].ys, BL_MOB);
+		}
+	}
+	return 0;
+}
+

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -59,6 +59,7 @@
 #include "pc.h"
 #include "bonus.h"
 #include "script.h"
+#include "script_internal.h"
 #include "storage.h"
 #include "mob.h"
 #include "npc.h"
@@ -199,54 +200,6 @@ struct script_function {
 } buildin_func[];
 
 static struct linkdb_node *sleep_db = NULL;
-
-enum {
-	C_NOP = 0,
-	C_POS,
-	C_INT,
-	C_PARAM,
-	C_FUNC,
-	C_STR,
-	C_CONSTSTR,
-	C_PTR,
-	C_ARG,
-	C_NAME,
-	C_EOL,
-	C_RETINFO,
-
-	// ユーザ定義関数群
-	C_USERFUNC,
-	C_USERFUNC_POS,
-
-	// operator
-	C_OP3,
-	C_LOR,
-	C_LAND,
-	C_LE,
-	C_LT,
-	C_GE,
-	C_GT,
-	C_EQ,
-	C_NE,
-	C_XOR,
-	C_OR,
-	C_AND,
-	C_ADD,
-	C_SUB,
-	C_MUL,
-	C_DIV,
-	C_MOD,
-	C_POW,
-	C_NEG,
-	C_LNOT,
-	C_NOT,
-	C_R_SHIFT,
-	C_L_SHIFT,
-	C_ADD_PRE,
-	C_SUB_PRE,
-	C_ADD_POST,
-	C_SUB_POST,
-};
 
 
 /*==========================================
@@ -2333,20 +2286,12 @@ int script_is_error(struct script_code *code)
 //
 // 実行系
 //
-enum {
-	RUN = 0,
-	STOP,
-	END,
-	RERUNLINE,
-	GOTO,
-	RETFUNC
-};
 
 /*==========================================
  * ridからsdへの解決
  *------------------------------------------
  */
-static struct map_session_data *script_rid2sd(struct script_state *st)
+struct map_session_data *script_rid2sd(struct script_state *st)
 {
 	struct map_session_data *sd=map_id2sd(st->rid);
 
@@ -2360,7 +2305,7 @@ static struct map_session_data *script_rid2sd(struct script_state *st)
  * script情報からメモリアルID取得
  *------------------------------------------
  */
-static int script_getmemorialid(struct script_state *st)
+int script_getmemorialid(struct script_state *st)
 {
 	struct npc_data *nd = map_id2nd(st->oid);
 	int memorial_id = 0;
@@ -2393,7 +2338,7 @@ static int script_getmemorialid(struct script_state *st)
  * 変数の読み取り
  *------------------------------------------
  */
-static void get_val(struct script_state *st,struct script_data *data)
+void get_val(struct script_state *st,struct script_data *data)
 {
 	struct map_session_data *sd = NULL;
 	char *name;
@@ -2546,7 +2491,7 @@ static void get_val(struct script_state *st,struct script_data *data)
  * 変数の読み取り2
  *------------------------------------------
  */
-static void* get_val2(struct script_state *st,int num,struct linkdb_node **ref)
+void* get_val2(struct script_state *st,int num,struct linkdb_node **ref)
 {
 	struct script_data dat;
 
@@ -2562,7 +2507,7 @@ static void* get_val2(struct script_state *st,int num,struct linkdb_node **ref)
  * 変数設定用
  *------------------------------------------
  */
-static int set_reg(struct script_state *st,struct map_session_data *sd,int num,const char *name,const void *v,struct linkdb_node** ref)
+int set_reg(struct script_state *st,struct map_session_data *sd,int num,const char *name,const void *v,struct linkdb_node** ref)
 {
 	char prefix  = *name;
 	char postfix = name[strlen(name)-1];
@@ -2693,7 +2638,7 @@ static int set_reg(struct script_state *st,struct map_session_data *sd,int num,c
  * 文字列への変換
  *------------------------------------------
  */
-static char* conv_str(struct script_state *st,struct script_data *data)
+char* conv_str(struct script_state *st,struct script_data *data)
 {
 	get_val(st,data);
 
@@ -2726,7 +2671,7 @@ static char* conv_str(struct script_state *st,struct script_data *data)
  * 数値へ変換
  *------------------------------------------
  */
-static int conv_num(struct script_state *st,struct script_data *data)
+int conv_num(struct script_state *st,struct script_data *data)
 {
 	get_val(st,data);
 	if(data->type == C_STR || data->type == C_CONSTSTR) {
@@ -2754,7 +2699,7 @@ static void expand_stack(struct script_stack *stack)
  * スタックへ数値をプッシュ
  *------------------------------------------
  */
-static void push_val(struct script_stack *stack,int type,int val)
+void push_val(struct script_stack *stack,int type,int val)
 {
 	if(stack->sp >= stack->sp_max)
 		expand_stack(stack);
@@ -2769,7 +2714,7 @@ static void push_val(struct script_stack *stack,int type,int val)
  * スタックへ数値＋リファレンスをプッシュ
  *------------------------------------------
  */
-static void push_val2(struct script_stack *stack,int type,int val,struct linkdb_node** ref)
+void push_val2(struct script_stack *stack,int type,int val,struct linkdb_node** ref)
 {
 	push_val(stack,type,val);
 	stack->stack_data[stack->sp-1].ref = ref;
@@ -2779,7 +2724,7 @@ static void push_val2(struct script_stack *stack,int type,int val,struct linkdb_
  * スタックへ文字列をプッシュ
  *------------------------------------------
  */
-static void push_str(struct script_stack *stack,int type,unsigned char *str)
+void push_str(struct script_stack *stack,int type,unsigned char *str)
 {
 	if(stack->sp >= stack->sp_max)
 		expand_stack(stack);
@@ -2794,7 +2739,7 @@ static void push_str(struct script_stack *stack,int type,unsigned char *str)
  * スタックへポインタをプッシュ
  *------------------------------------------
  */
-static void push_ptr(struct script_stack *stack,int type,void *ptr)
+void push_ptr(struct script_stack *stack,int type,void *ptr)
 {
 	if(stack->sp >= stack->sp_max)
 		expand_stack(stack);
@@ -2809,7 +2754,7 @@ static void push_ptr(struct script_stack *stack,int type,void *ptr)
  * スタックへ複製をプッシュ
  *------------------------------------------
  */
-static void push_copy(struct script_stack *stack,int pos)
+void push_copy(struct script_stack *stack,int pos)
 {
 	switch(stack->stack_data[pos].type){
 	case C_CONSTSTR:
@@ -2834,7 +2779,7 @@ static void push_copy(struct script_stack *stack,int pos)
  * スタックからポップ
  *------------------------------------------
  */
-static void pop_stack(struct script_stack* stack,int start,int end)
+void pop_stack(struct script_stack* stack,int start,int end)
 {
 	int i;
 
@@ -2980,7 +2925,7 @@ static int pop_val(struct script_state* st)
  * 文字列型かどうか判定
  *------------------------------------------
  */
-static int isstr(struct script_data *c)
+int isstr(struct script_data *c)
 {
 	if( c->type == C_STR || c->type == C_CONSTSTR )
 		return 1;
@@ -3768,7 +3713,7 @@ int script_config_read(const char *cfgName)
  * "this" を考慮してmap名からmap番号へ変換
  *------------------------------------------
  */
-static int script_mapname2mapid(struct script_state *st,const char *mapname)
+int script_mapname2mapid(struct script_state *st,const char *mapname)
 {
 	if(strcmp(mapname,"this")==0)
 	{
@@ -5162,131 +5107,6 @@ int buildin_rand(struct script_state *st)
 	return 0;
 }
 
-/*==========================================
- *
- *------------------------------------------
- */
-static int script_warp(struct map_session_data *sd, const char *mapname, int x, int y)
-{
-	nullpo_retr(0, sd);
-
-	if(strcmp(mapname, "Random") == 0) {
-		pc_randomwarp(sd, 3);
-	} else if(strcmp(mapname, "SavePoint") == 0) {
-		pc_setpos(sd, sd->status.save_point.map, sd->status.save_point.x, sd->status.save_point.y, 3);
-	} else {
-		if(pc_setpos(sd, mapname, x, y, 0)) {
-			// 失敗したので .gat を付けてリトライ
-			char *str = (char *)aMalloc(strlen(mapname) + 5);
-			memcpy(str, mapname, strlen(mapname) + 1);
-			strcat(str, ".gat");
-			pc_setpos(sd, str, x, y, 0);
-			aFree(str);
-		}
-	}
-
-	if(unit_isdead(&sd->bl)) {
-		pc_setstand(sd);
-		pc_setrestartvalue(sd, 3);
-	}
-
-	return 0;
-}
-
-/*==========================================
- *
- *------------------------------------------
- */
-int buildin_warp(struct script_state *st)
-{
-	int x,y;
-	char *str;
-	struct block_list *bl = map_id2bl(st->rid);
-
-	nullpo_retr(0, bl);
-
-	str=conv_str(st,& (st->stack->stack_data[st->start+2]));
-	x=conv_num(st,& (st->stack->stack_data[st->start+3]));
-	y=conv_num(st,& (st->stack->stack_data[st->start+4]));
-
-	if(bl->type == BL_PC) {
-		script_warp((struct map_session_data *)bl, str, x, y);
-	} else if(bl->type == BL_MOB) {
-		struct mob_data *md = (struct mob_data *)bl;
-
-		if(strcmp(str, "Random") == 0) {
-			mob_warp(md, -1, -1, -1, 3);
-		} else {
-			int m = map_mapname2mapid(str);
-			if(m >= 0)
-				mob_warp(md, m, x, y, 3);
-		}
-	}
-	return 0;
-}
-
-/*==========================================
- * MAP指定ワープ
- *------------------------------------------
- */
-static int buildin_mapwarp_sub(struct block_list *bl,va_list ap)
-{
-	int x,y;
-	char *mapname;
-	struct map_session_data *sd;
-
-	nullpo_retr(0, bl);
-	nullpo_retr(0, sd = (struct map_session_data *)bl);
-
-	mapname = va_arg(ap, char *);
-	x = va_arg(ap,int);
-	y = va_arg(ap,int);
-
-	script_warp(sd, mapname, x, y);
-
-	return 0;
-}
-
-int buildin_mapwarp(struct script_state *st)
-{
-	int x,y,m;
-	char *mapname, *str;
-
-	mapname=conv_str(st,& (st->stack->stack_data[st->start+2]));
-	str=conv_str(st,& (st->stack->stack_data[st->start+3]));
-	x=conv_num(st,& (st->stack->stack_data[st->start+4]));
-	y=conv_num(st,& (st->stack->stack_data[st->start+5]));
-
-	m = script_mapname2mapid(st,mapname);
-	if(m >= 0)
-		map_foreachinarea(buildin_mapwarp_sub,m,0,0,map[m].xs,map[m].ys,BL_PC,str,x,y);
-	return 0;
-}
-
-/*==========================================
- * エリア指定ワープ
- *------------------------------------------
- */
-int buildin_areawarp(struct script_state *st)
-{
-	int x,y,m;
-	char *mapname, *str;
-	int x0,y0,x1,y1;
-
-	mapname=conv_str(st,& (st->stack->stack_data[st->start+2]));
-	x0=conv_num(st,& (st->stack->stack_data[st->start+3]));
-	y0=conv_num(st,& (st->stack->stack_data[st->start+4]));
-	x1=conv_num(st,& (st->stack->stack_data[st->start+5]));
-	y1=conv_num(st,& (st->stack->stack_data[st->start+6]));
-	str=conv_str(st,& (st->stack->stack_data[st->start+7]));
-	x=conv_num(st,& (st->stack->stack_data[st->start+8]));
-	y=conv_num(st,& (st->stack->stack_data[st->start+9]));
-
-	m = script_mapname2mapid(st,mapname);
-	if(m >= 0)
-		map_foreachinarea(buildin_mapwarp_sub,m,x0,y0,x1,y1,BL_PC,str,x,y);
-	return 0;
-}
 
 /*==========================================
  *
@@ -7567,21 +7387,6 @@ int buildin_stand(struct script_state *st)
 	return 0;
 }
 
-/*==========================================
- * セーブポイントの保存
- *------------------------------------------
- */
-int buildin_savepoint(struct script_state *st)
-{
-	int x,y;
-	char *str;
-
-	str=conv_str(st,& (st->stack->stack_data[st->start+2]));
-	x=conv_num(st,& (st->stack->stack_data[st->start+3]));
-	y=conv_num(st,& (st->stack->stack_data[st->start+4]));
-	pc_setsavepoint(script_rid2sd(st),str,x,y);
-	return 0;
-}
 
 /*==========================================
  * GetTimeTick(0: System Tick, 1: Time Second Tick)
@@ -8180,309 +7985,6 @@ int buildin_setnpctimer(struct script_state *st)
 	return 0;
 }
 
-/*==========================================
- * 天の声アナウンス
- *------------------------------------------
- */
-int buildin_announce(struct script_state *st)
-{
-	char *str = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	int flag  = conv_num(st,& (st->stack->stack_data[st->start+3]));
-	size_t len;
-	int color = 0;
-	int type = 400;
-	int size = 12;
-	int align = 0;
-	int pos_y = 0;
-
-	if(st->end > st->start+4)
-		color = conv_num(st,& (st->stack->stack_data[st->start+4]));
-	if(st->end > st->start+5)
-		type = conv_num(st,& (st->stack->stack_data[st->start+5]));
-	if(st->end > st->start+6)
-		size = conv_num(st,& (st->stack->stack_data[st->start+6]));
-	if(st->end > st->start+7)
-		align = conv_num(st,& (st->stack->stack_data[st->start+7]));
-	if(st->end > st->start+8)
-		pos_y = conv_num(st,& (st->stack->stack_data[st->start+8]));
-
-	len = strlen(str)+1;
-
-	if(flag&0x07) {
-		struct block_list *bl = NULL;
-		if(flag&0x08) {
-			bl = map_id2bl(st->oid);
-		} else {
-			struct map_session_data *sd = script_rid2sd(st);
-			if(sd)
-				bl = &sd->bl;
-		}
-		if(bl == NULL)
-			return 0;
-
-		if(color)
-			clif_announce(bl,str,len,(unsigned int)color,type,size,align,pos_y,flag);
-		else
-			clif_GMmessage(bl,str,len,flag);
-	} else {
-		if(color)
-			intif_announce(str,len,(unsigned int)color,type,size,align,pos_y);
-		else
-			intif_GMmessage(str,len,flag);
-	}
-	return 0;
-}
-
-/*==========================================
- * 天の声アナウンス（特定マップ）
- *------------------------------------------
- */
-static int buildin_mapannounce_sub(struct block_list *bl,va_list ap)
-{
-	char *str;
-	size_t len;
-	int color;
-	int flag;
-	int type,size,align,pos_y;
-
-	nullpo_retr(0, bl);
-
-	str   = va_arg(ap,char *);
-	len   = va_arg(ap,size_t);
-	flag  = va_arg(ap,int);
-	color = va_arg(ap,int);
-	type  = va_arg(ap,int);
-	size  = va_arg(ap,int);
-	align = va_arg(ap,int);
-	pos_y = va_arg(ap,int);
-
-	if(color)
-		clif_announce(bl,str,len,(unsigned int)color,type,size,align,pos_y,flag|3);
-	else
-		clif_GMmessage(bl,str,len,flag|3);
-	return 0;
-}
-
-int buildin_mapannounce(struct script_state *st)
-{
-	char *mapname,*str;
-	int color = 0;
-	int flag,m;
-	int type = 400;
-	int size = 12;
-	int align = 0;
-	int pos_y = 0;
-
-	mapname=conv_str(st,& (st->stack->stack_data[st->start+2]));
-	str=conv_str(st,& (st->stack->stack_data[st->start+3]));
-	flag=conv_num(st,& (st->stack->stack_data[st->start+4]));
-	if (st->end>st->start+5)
-		color=conv_num(st,& (st->stack->stack_data[st->start+5]));
-	if (st->end>st->start+6)
-		type=conv_num(st,& (st->stack->stack_data[st->start+6]));
-	if (st->end>st->start+7)
-		size=conv_num(st,& (st->stack->stack_data[st->start+7]));
-	if (st->end>st->start+8)
-		align=conv_num(st,& (st->stack->stack_data[st->start+8]));
-	if (st->end>st->start+9)
-		pos_y=conv_num(st,& (st->stack->stack_data[st->start+9]));
-
-	m = script_mapname2mapid(st,mapname);
-	if(m >= 0)
-		map_foreachinarea(buildin_mapannounce_sub,m,0,0,map[m].xs,map[m].ys,BL_PC,str,strlen(str)+1,flag&0x10,color,type,size,align,pos_y);
-	return 0;
-}
-
-/*==========================================
- * 天の声アナウンス（特定エリア）
- *------------------------------------------
- */
-int buildin_areaannounce(struct script_state *st)
-{
-	char *mapname,*str;
-	int flag,m;
-	int x0,y0,x1,y1;
-	int color = 0;
-	int type = 400;
-	int size = 12;
-	int align = 0;
-	int pos_y = 0;
-
-	mapname = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	x0      = conv_num(st,& (st->stack->stack_data[st->start+3]));
-	y0      = conv_num(st,& (st->stack->stack_data[st->start+4]));
-	x1      = conv_num(st,& (st->stack->stack_data[st->start+5]));
-	y1      = conv_num(st,& (st->stack->stack_data[st->start+6]));
-	str     = conv_str(st,& (st->stack->stack_data[st->start+7]));
-	flag    = conv_num(st,& (st->stack->stack_data[st->start+8]));
-	if (st->end>st->start+9)
-		color = conv_num(st,& (st->stack->stack_data[st->start+9]));
-	if (st->end>st->start+10)
-		type = conv_num(st,& (st->stack->stack_data[st->start+10]));
-	if (st->end>st->start+11)
-		size = conv_num(st,& (st->stack->stack_data[st->start+11]));
-	if (st->end>st->start+12)
-		align = conv_num(st,& (st->stack->stack_data[st->start+12]));
-	if (st->end>st->start+13)
-		pos_y = conv_num(st,& (st->stack->stack_data[st->start+13]));
-
-	m = script_mapname2mapid(st,mapname);
-	if(m >= 0)
-		map_foreachinarea(buildin_mapannounce_sub,m,x0,y0,x1,y1,BL_PC,str,strlen(str)+1,flag&0x10,color,type,size,align,pos_y);
-	return 0;
-}
-
-/*==========================================
- * ユーザー数取得
- *------------------------------------------
- */
-int buildin_getusers(struct script_state *st)
-{
-	int flag=conv_num(st,& (st->stack->stack_data[st->start+2]));
-	int val = -1;
-
-	switch(flag&0x07){
-		case 0:
-		{
-			struct block_list *bl=map_id2bl( (flag&0x08)? st->oid: st->rid );
-			if(bl)
-				val=map[bl->m].users;
-			break;
-		}
-		case 1:
-			val=map_getusers();
-			break;
-	}
-	push_val(st->stack,C_INT,val);
-	return 0;
-}
-
-/*==========================================
- * 繋いでるユーザーの全員の名前取得
- *------------------------------------------
- */
-int buildin_getusersname(struct script_state *st)
-{
-	struct map_session_data *sd = script_rid2sd(st);
-	struct map_session_data *pl_sd = NULL;
-	int i=0,disp_num=1;
-
-	nullpo_retr(0, sd);
-
-	for (i=0;i<fd_max;i++) {
-		if(session[i] && (pl_sd = (struct map_session_data *)session[i]->session_data) && pl_sd->state.auth){
-			if( !(battle_config.hide_GM_session && pc_isGM(pl_sd)) ){
-				if((disp_num++)%10==0)
-					clif_scriptnext(sd,st->oid);
-				clif_scriptmes(sd,st->oid,pl_sd->status.name);
-			}
-		}
-	}
-	return 0;
-}
-
-/*==========================================
- * マップ指定ユーザー数取得
- *------------------------------------------
- */
-int buildin_getmapusers(struct script_state *st)
-{
-	char *str;
-	int m;
-
-	str=conv_str(st,& (st->stack->stack_data[st->start+2]));
-
-	m = script_mapname2mapid(st,str);
-	if(m < 0)
-		push_val(st->stack,C_INT,-1);
-	else
-		push_val(st->stack,C_INT,map[m].users);
-	return 0;
-}
-
-/*==========================================
- * エリア指定ユーザー数取得
- *------------------------------------------
- */
-static int buildin_getareausers_sub(struct block_list *bl,va_list ap)
-{
-	return 1;
-}
-
-int buildin_getareausers(struct script_state *st)
-{
-	char *str;
-	int m,x0,y0,x1,y1,users=0;
-
-	str=conv_str(st,& (st->stack->stack_data[st->start+2]));
-	x0=conv_num(st,& (st->stack->stack_data[st->start+3]));
-	y0=conv_num(st,& (st->stack->stack_data[st->start+4]));
-	x1=conv_num(st,& (st->stack->stack_data[st->start+5]));
-	y1=conv_num(st,& (st->stack->stack_data[st->start+6]));
-
-	m = script_mapname2mapid(st,str);
-	if(m < 0) {
-		push_val(st->stack,C_INT,-1);
-		return 0;
-	}
-	users = map_foreachinarea(buildin_getareausers_sub,m,x0,y0,x1,y1,BL_PC);
-	push_val(st->stack,C_INT,users);
-	return 0;
-}
-
-/*==========================================
- * エリア指定ドロップアイテム数取得
- *------------------------------------------
- */
-static int buildin_getareadropitem_sub(struct block_list *bl,va_list ap)
-{
-	int item=va_arg(ap,int);
-	struct flooritem_data *fitem;
-
-	nullpo_retr(0, bl);
-	nullpo_retr(0, fitem = (struct flooritem_data *)bl);
-
-	if(fitem->item_data.nameid == item)
-		return fitem->item_data.amount;
-
-	return 0;
-}
-
-int buildin_getareadropitem(struct script_state *st)
-{
-	char *str;
-	int m,x0,y0,x1,y1,item=0,amount=0;
-	struct script_data *data;
-
-	str = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	x0  = conv_num(st,& (st->stack->stack_data[st->start+3]));
-	y0  = conv_num(st,& (st->stack->stack_data[st->start+4]));
-	x1  = conv_num(st,& (st->stack->stack_data[st->start+5]));
-	y1  = conv_num(st,& (st->stack->stack_data[st->start+6]));
-
-	data = &(st->stack->stack_data[st->start+7]);
-	get_val(st,data);
-	if( isstr(data) ) {
-		const char *name = conv_str(st,data);
-		struct item_data *item_data = itemdb_searchname(name);
-		if(item_data)
-			item = item_data->nameid;
-	} else {
-		item = conv_num(st,data);
-	}
-
-	m = script_mapname2mapid(st,str);
-	if(m < 0) {
-		push_val(st->stack,C_INT,-1);
-		return 0;
-	}
-	if(item > 0) {
-		amount = map_foreachinarea(buildin_getareadropitem_sub,m,x0,y0,x1,y1,BL_ITEM,item);
-	}
-	push_val(st->stack,C_INT,amount);
-
-	return 0;
-}
 
 /*==========================================
  * NPCの有効化
@@ -9362,296 +8864,6 @@ int buildin_isloggedin(struct script_state *st)
 	return 0;
 }
 
-/*==========================================
- * マップフラグのindexからアドレスを返す
- *------------------------------------------
- */
-static int* script_conv_mapflag(int m,int type)
-{
-	if(m < 0)
-		return NULL;
-
-	switch(type) {
-		case MF_NOSAVE:             return &map[m].flag.nosave;
-		case MF_NOMEMO:             return &map[m].flag.nomemo;
-		case MF_NOTELEPORT:         return &map[m].flag.noteleport;
-		case MF_NOPORTAL:           return &map[m].flag.noportal;
-		case MF_NORETURN:           return &map[m].flag.noreturn;
-		case MF_MONSTER_NOTELEPORT: return &map[m].flag.monster_noteleport;
-		case MF_NOBRANCH:           return &map[m].flag.nobranch;
-		case MF_NOPENALTY:          return &map[m].flag.nopenalty;
-		case MF_PVP:                return &map[m].flag.pvp;
-		case MF_PVP_NOPARTY:        return &map[m].flag.pvp_noparty;
-		case MF_PVP_NOGUILD:        return &map[m].flag.pvp_noguild;
-		case MF_PVP_NIGHTMAREDROP:  return &map[m].flag.pvp_nightmaredrop;
-		case MF_PVP_NOCALCRANK:     return &map[m].flag.pvp_nocalcrank;
-		case MF_GVG:                return &map[m].flag.gvg;
-		case MF_GVG_NOPARTY:        return &map[m].flag.gvg_noparty;
-		case MF_GVG_NIGHTMAREDROP:  return &map[m].flag.gvg_nightmaredrop;
-		case MF_NOZENYPENALTY:      return &map[m].flag.nozenypenalty;
-		case MF_NOTRADE:            return &map[m].flag.notrade;
-		case MF_NOSKILL:            return &map[m].flag.noskill;
-		case MF_NOABRA:             return &map[m].flag.noabra;
-		case MF_NODROP:             return &map[m].flag.nodrop;
-		case MF_SNOW:               return &map[m].flag.snow;
-		case MF_FOG:                return &map[m].flag.fog;
-		case MF_SAKURA:             return &map[m].flag.sakura;
-		case MF_LEAVES:             return &map[m].flag.leaves;
-		case MF_RAIN:               return &map[m].flag.rain;
-		case MF_FIREWORKS:          return &map[m].flag.fireworks;
-		case MF_CLOUD1:             return &map[m].flag.cloud1;
-		case MF_CLOUD2:             return &map[m].flag.cloud2;
-		case MF_CLOUD3:             return &map[m].flag.cloud3;
-		case MF_BASEEXP_RATE:       return &map[m].flag.base_exp_rate;
-		case MF_JOBEXP_RATE:        return &map[m].flag.job_exp_rate;
-		case MF_PK:                 return &map[m].flag.pk;
-		case MF_PK_NOPARTY:         return &map[m].flag.pk_noparty;
-		case MF_PK_NOGUILD:         return &map[m].flag.pk_noguild;
-		case MF_PK_NIGHTMAREDROP:   return &map[m].flag.pk_nightmaredrop;
-		case MF_PK_NOCALCRANK:      return &map[m].flag.pk_nocalcrank;
-		case MF_NOICEWALL:          return &map[m].flag.noicewall;
-		case MF_TURBO:              return &map[m].flag.turbo;
-		case MF_NOREVIVE:           return &map[m].flag.norevive;
-		case MF_NOCOMMAND:          return &map[m].flag.nocommand;
-		case MF_NOJUMP:             return &map[m].flag.nojump;
-		case MF_NOCOSTUME:          return &map[m].flag.nocostume;
-		case MF_TOWN:               return &map[m].flag.town;
-		case MF_DAMAGE_RATE:        return &map[m].flag.damage_rate;
-	}
-	return NULL;
-}
-
-/*==========================================
- * マップフラグを設定する
- *------------------------------------------
- */
-int buildin_setmapflag(struct script_state *st)
-{
-	char *mapname = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	int type = conv_num(st,& (st->stack->stack_data[st->start+3]));
-	int m;
-	int *flag;
-
-	if((m = script_mapname2mapid(st,mapname)) < 0)
-		return 0;
-	flag = script_conv_mapflag(m, type);
-
-	if(flag)
-	{
-		*flag = 1;
-		switch (type) {		// 特殊処理が必要なマップフラグ
-		case MF_NOSAVE:
-			if(st->end > st->start+6) {
-				char *str = conv_str(st,& (st->stack->stack_data[st->start+4]));
-				int x     = conv_num(st,& (st->stack->stack_data[st->start+5]));
-				int y     = conv_num(st,& (st->stack->stack_data[st->start+6]));
-				strncpy(map[m].save.map, str, 16);
-				map[m].save.map[15] = '\0';	// force \0 terminal
-				map[m].save.x = x;
-				map[m].save.y = y;
-			}
-			break;
-		case MF_BASEEXP_RATE:
-		case MF_JOBEXP_RATE:
-		case MF_NOCOMMAND:
-		case MF_DAMAGE_RATE:
-			if(st->end > st->start+4) {
-				*flag = conv_num(st,& (st->stack->stack_data[st->start+4]));
-			}
-			break;
-		case MF_PVP_NIGHTMAREDROP:
-		case MF_GVG_NIGHTMAREDROP:
-		case MF_PK_NIGHTMAREDROP:
-			if(st->end > st->start+6) {
-				char buf[128];
-				char *arg1 = conv_str(st,& (st->stack->stack_data[st->start+4]));
-				char *arg2 = conv_str(st,& (st->stack->stack_data[st->start+5]));
-				int  per   = conv_num(st,& (st->stack->stack_data[st->start+6]));
-				snprintf(buf, sizeof(buf), "%s,%s,%d", arg1, arg2, per);
-				npc_set_mapflag_sub(m, buf, type);
-			}
-			break;
-		}
-		map_field_setting();
-	}
-	return 0;
-}
-
-/*==========================================
- * マップフラグを削除する
- *------------------------------------------
- */
-int buildin_removemapflag(struct script_state *st)
-{
-	char *mapname = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	int type = conv_num(st,& (st->stack->stack_data[st->start+3]));
-	int m;
-	int *flag;
-
-	if((m = script_mapname2mapid(st,mapname)) < 0)
-		return 0;
-	flag = script_conv_mapflag(m, type);
-
-	if(flag)
-	{
-		*flag = 0;
-		switch (type) {		// 特殊処理が必要なマップフラグ
-		case MF_PVP_NIGHTMAREDROP:
-		case MF_GVG_NIGHTMAREDROP:
-		case MF_PK_NIGHTMAREDROP:
-			{
-				int i,j;
-				for(i=0; i<MAX_DROP_PER_MAP; i++) {	// 該当のドロップリストを削除して空きを詰める
-					if(map[m].drop_list[i].drop_id == 0)
-						break;
-					if(map[m].drop_list[i].drop_flag != type)
-						continue;
-					for(j=i+1; j<MAX_DROP_PER_MAP && map[m].drop_list[j].drop_id != 0; j++);
-					j--;
-					if(i != j) {
-						memcpy(&map[m].drop_list[i], &map[m].drop_list[j], sizeof(map[m].drop_list[0]));
-					}
-					memset(&map[m].drop_list[j], 0, sizeof(map[m].drop_list[0]));
-					i--;
-				}
-			}
-			break;
-		}
-		map_field_setting();
-	}
-	return 0;
-}
-
-/*==========================================
- * マップフラグのチェック
- *------------------------------------------
- */
-int buildin_checkmapflag(struct script_state *st)
-{
-	char *mapname = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	int type = conv_num(st,& (st->stack->stack_data[st->start+3]));
-	int m;
-	int *flag;
-
-	if((m = script_mapname2mapid(st,mapname)) < 0) {
-		push_val(st->stack,C_INT,-1);
-		return 0;
-	}
-
-	flag = script_conv_mapflag(m ,type);
-
-	push_val(st->stack,C_INT,((flag)? *flag: -1));
-	return 0;
-}
-
-/*==========================================
- * PvPオン
- *------------------------------------------
- */
-int buildin_pvpon(struct script_state *st)
-{
-	char *str;
-	int m;
-
-	str = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	m = script_mapname2mapid(st,str);
-	if(m >= 0 && !map[m].flag.pvp) {
-		int i;
-		struct map_session_data *pl_sd;
-		unsigned int tick = gettick();
-
-		map[m].flag.pvp = 1;
-		clif_send0199(m,1);
-
-		for(i=0; i<fd_max; i++) {	// 人数分ループ
-			if(session[i] && (pl_sd = (struct map_session_data *)session[i]->session_data) && pl_sd->state.auth) {
-				if(m == pl_sd->bl.m && pl_sd->pvp_timer == -1) {
-					pl_sd->pvp_timer = add_timer(tick+200,pc_calc_pvprank_timer,pl_sd->bl.id,NULL);
-					pl_sd->pvp_rank = 0;
-					pl_sd->pvp_lastusers = 0;
-					pl_sd->pvp_point = 5;
-				}
-			}
-		}
-		map_field_setting();
-	}
-	return 0;
-}
-
-/*==========================================
- * PvPオフ
- *------------------------------------------
- */
-int buildin_pvpoff(struct script_state *st)
-{
-	char *str;
-	int m;
-
-	str = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	m = script_mapname2mapid(st,str);
-	if(m >= 0 && map[m].flag.pvp) {
-		int i;
-		struct map_session_data *pl_sd;
-
-		map[m].flag.pvp = 0;
-		clif_send0199(m,0);
-
-		for(i=0; i<fd_max; i++) {	// 人数分ループ
-			if(session[i] && (pl_sd = (struct map_session_data *)session[i]->session_data) && pl_sd->state.auth) {
-				if(m == pl_sd->bl.m) {
-					clif_pvpset(pl_sd,0,0,2);
-					if(pl_sd->pvp_timer != -1) {
-						delete_timer(pl_sd->pvp_timer,pc_calc_pvprank_timer);
-						pl_sd->pvp_timer = -1;
-					}
-				}
-			}
-		}
-		map_field_setting();
-	}
-
-	return 0;
-}
-
-/*==========================================
- * GvGオン
- *------------------------------------------
- */
-int buildin_gvgon(struct script_state *st)
-{
-	char *str;
-	int m;
-
-	str = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	m = script_mapname2mapid(st,str);
-	if(m >= 0 && !map[m].flag.gvg) {
-		map[m].flag.gvg = 1;
-		clif_send0199(m,3);
-		map_field_setting();
-	}
-
-	return 0;
-}
-
-/*==========================================
- * GvGオフ
- *------------------------------------------
- */
-int buildin_gvgoff(struct script_state *st)
-{
-	char *str;
-	int m;
-
-	str = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	m = script_mapname2mapid(st,str);
-	if(m >= 0 && map[m].flag.gvg) {
-		map[m].flag.gvg = 0;
-		clif_send0199(m,0);
-		map_field_setting();
-	}
-
-	return 0;
-}
 
 /*==========================================
  * NPCエモーション
@@ -9685,64 +8897,6 @@ int buildin_emotion(struct script_state *st)
 				clif_emotion_self((struct map_session_data *)bl,bl,type);
 			else
 				clif_emotion(bl,type);
-		}
-	}
-	return 0;
-}
-
-/*==========================================
- * 特定対象を移動、攻城戦用
- *------------------------------------------
- */
-static int buildin_maprespawnguildid_sub_pc(struct map_session_data *sd, va_list ap)
-{
-	int m    = va_arg(ap, int);
-	int g_id = va_arg(ap, int);
-	int flag = va_arg(ap, int);
-
-	nullpo_retr(0, sd);
-
-	if(sd->bl.m == m) {
-		// ワープ中などでブロックリストから外れたPCも対象とするかどうか
-		if(battle_config.maprespawnguildid_all_players || sd->bl.prev) {
-			int match = (g_id > 0 && sd->status.guild_id == g_id);
-			if( (flag&1 && match) || (flag&2 && !match) )
-				pc_setpos(sd, sd->status.save_point.map, sd->status.save_point.x, sd->status.save_point.y, 3);
-		}
-	}
-
-	return 0;
-}
-
-static int buildin_maprespawnguildid_sub_mob(struct block_list *bl, va_list ap)
-{
-	struct mob_data *md = NULL;
-
-	nullpo_retr(0, bl);
-
-	if(bl->type != BL_MOB || (md = (struct mob_data *)bl) == NULL)
-		return 0;
-
-	if(!md->guild_id)
-		unit_remove_map(&md->bl, 1, 0);
-
-	return 0;
-}
-
-int buildin_maprespawnguildid(struct script_state *st)
-{
-	char *mapname = conv_str(st,& (st->stack->stack_data[st->start+2]));
-	int g_id      = conv_num(st,& (st->stack->stack_data[st->start+3]));
-	int flag      = conv_num(st,& (st->stack->stack_data[st->start+4]));
-	int m;
-
-	m = script_mapname2mapid(st,mapname);
-	if(m >= 0) {
-		if(flag&3) {
-			clif_foreachclient(buildin_maprespawnguildid_sub_pc, m, g_id, flag);
-		}
-		if(flag&4) {
-			map_foreachinarea(buildin_maprespawnguildid_sub_mob, m, 0, 0, map[m].xs, map[m].ys, BL_MOB);
 		}
 	}
 	return 0;
@@ -15317,3 +14471,4 @@ int buildin_setunittitle(struct script_state *st)
 
 	return 0;
 }
+

--- a/src/map/script_internal.h
+++ b/src/map/script_internal.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2002-2020  Auriga
+ *
+ * This file is part of Auriga.
+ *
+ * Internal declarations shared by script*.c / buildin_*.c
+ * (not part of public script.h API).
+ * Introduced for Issue #61 file split.
+ */
+
+#ifndef _SCRIPT_INTERNAL_H_
+#define _SCRIPT_INTERNAL_H_
+
+#include "script.h"
+
+/* script bytecode / stack data types */
+enum {
+	C_NOP = 0,
+	C_POS,
+	C_INT,
+	C_PARAM,
+	C_FUNC,
+	C_STR,
+	C_CONSTSTR,
+	C_PTR,
+	C_ARG,
+	C_NAME,
+	C_EOL,
+	C_RETINFO,
+
+	/* user-defined functions */
+	C_USERFUNC,
+	C_USERFUNC_POS,
+
+	/* operators */
+	C_OP3,
+	C_LOR,
+	C_LAND,
+	C_LE,
+	C_LT,
+	C_GE,
+	C_GT,
+	C_EQ,
+	C_NE,
+	C_XOR,
+	C_OR,
+	C_AND,
+	C_ADD,
+	C_SUB,
+	C_MUL,
+	C_DIV,
+	C_MOD,
+	C_POW,
+	C_NEG,
+	C_LNOT,
+	C_NOT,
+	C_R_SHIFT,
+	C_L_SHIFT,
+	C_ADD_PRE,
+	C_SUB_PRE,
+	C_ADD_POST,
+	C_SUB_POST,
+};
+
+/* script execution state */
+enum {
+	RUN = 0,
+	STOP,
+	END,
+	RERUNLINE,
+	GOTO,
+	RETFUNC
+};
+
+struct map_session_data *script_rid2sd(struct script_state *st);
+int script_getmemorialid(struct script_state *st);
+
+void get_val(struct script_state *st, struct script_data *data);
+void *get_val2(struct script_state *st, int num, struct linkdb_node **ref);
+int set_reg(struct script_state *st, struct map_session_data *sd, int num, const char *name, const void *v, struct linkdb_node **ref);
+
+char *conv_str(struct script_state *st, struct script_data *data);
+int conv_num(struct script_state *st, struct script_data *data);
+
+void push_val(struct script_stack *stack, int type, int val);
+void push_val2(struct script_stack *stack, int type, int val, struct linkdb_node **ref);
+void push_str(struct script_stack *stack, int type, unsigned char *str);
+void push_ptr(struct script_stack *stack, int type, void *ptr);
+void push_copy(struct script_stack *stack, int pos);
+void pop_stack(struct script_stack *stack, int start, int end);
+
+int isstr(struct script_data *c);
+int script_mapname2mapid(struct script_state *st, const char *mapname);
+
+int script_warp(struct map_session_data *sd, const char *mapname, int x, int y);
+
+#endif /* _SCRIPT_INTERNAL_H_ */

--- a/vcproj/map-server.vcxproj
+++ b/vcproj/map-server.vcxproj
@@ -137,6 +137,7 @@
     <ClInclude Include="..\src\map\quest.h" />
     <ClInclude Include="..\src\map\ranking.h" />
     <ClInclude Include="..\src\map\script.h" />
+    <ClInclude Include="..\src\map\script_internal.h" />
     <ClInclude Include="..\src\map\skill.h" />
     <ClInclude Include="..\src\map\skill_internal.h" />
     <ClInclude Include="..\src\map\status.h" />
@@ -206,6 +207,7 @@
     <ClCompile Include="..\src\map\quest.c" />
     <ClCompile Include="..\src\map\ranking.c" />
     <ClCompile Include="..\src\map\script.c" />
+    <ClCompile Include="..\src\map\buildin_map.c" />
     <ClCompile Include="..\src\map\skill.c" />
     <ClCompile Include="..\src\map\skill_castend_damage.c" />
     <ClCompile Include="..\src\map\skill_castend_ground.c" />

--- a/vcproj/map-server.vcxproj.filters
+++ b/vcproj/map-server.vcxproj.filters
@@ -103,6 +103,9 @@
     <ClCompile Include="..\src\map\script.c">
       <Filter>map_sql</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\map\buildin_map.c">
+      <Filter>map_sql</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\map\skill.c">
       <Filter>map_sql</Filter>
     </ClCompile>
@@ -313,6 +316,9 @@
       <Filter>map_sql</Filter>
     </ClInclude>
     <ClInclude Include="..\src\map\script.h">
+      <Filter>map_sql</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\map\script_internal.h">
       <Filter>map_sql</Filter>
     </ClInclude>
     <ClInclude Include="..\src\map\skill.h">


### PR DESCRIPTION
## Summary
- Issue #61 第1弾: `script.c` の map 系ビルドイン（warp / announce / mapflag / pvp・gvg 等）を `buildin_map.c` へ分離
- 共有ヘルパー（`conv_*` / `push_*` / `script_rid2sd` 等）と型列挙を `script_internal.h` 経由で公開。登録テーブル `buildin_func[]` は `script.c` に残置
- 挙動変更なし（リファクタのみ）。MSVC プロジェクトと CHANGELOG を更新

## Test plan
- [x] `vc_make.bat`（または相当ビルド）で map-server がリンクまで通る
- [ ] warp / mapwarp / areawarp / savepoint のスクリプト動作確認
- [ ] announce / mapannounce / areaannounce の表示確認
- [ ] setmapflag / removemapflag / checkmapflag と pvpon/off・gvgon/off の確認
- [ ] maprespawnguildid の確認（該当イベントがあれば）
