### PR TITLE
refactor: SQL接続設定を sqldbs_conninfo に共通化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ----------------------------------------
+//1619 [2026/08/10] by Cocoa
+
+・Issue #58: SQL 接続設定を sqldbs_conninfo に共通化（login/char/map/converter）（挙動変更なし）（sqldbs.c, sqldbs.h, account_sql.c, chardb_sql.c, mapreg_sql.c, converter.c）
+--------------------------------------------------------------------------------
 //1618 [2026/08/10] by Cocoa
 
 ・Issue #57: status_calc_pc / status_change_start / status_change_end をリファクタ。L_RECALC 再入を status_calc_ctrl で Unity 固定し、calc を phase 分割のうえ status_calc_pc.c へ、start/end を別 TU へ分離。SC ハンドラテーブルを導入し代表バッチを移行（挙動変更なし）（status.c, status_calc_ctrl.c, status_calc_ctrl.h, status_calc_pc.c, status_change_start.c, status_change_end.c, status_change_handlers.c, status_internal.h, tests/, map-server.vcxproj）

--- a/src/char/sql/chardb_sql.c
+++ b/src/char/sql/chardb_sql.c
@@ -33,13 +33,9 @@
 #include "chardb_sql.h"
 
 static struct dbt *char_db_;
-static unsigned short char_server_port = 3306;
-static char char_server_ip[32]      = "127.0.0.1";
-static char char_server_id[32]      = "ragnarok";
-static char char_server_pw[32]      = "ragnarok";
-static char char_server_db[32]      = "ragnarok";
-static char char_server_charset[32] = "";
-static int  char_server_keepalive   = 0;
+static struct sqldbs_conninfo char_server_info = {
+	"127.0.0.1", 3306, "ragnarok", "ragnarok", "ragnarok", "", 0
+};
 
 /*==========================================
  * ê›íËÉtÉ@ÉCÉãì«çû
@@ -47,24 +43,7 @@ static int  char_server_keepalive   = 0;
  */
 int chardb_sql_config_read_sub(const char* w1,const char* w2)
 {
-	if( strcmpi(w1,"char_server_ip") == 0 )
-		strncpy(char_server_ip, w2, sizeof(char_server_ip) - 1);
-	else if( strcmpi(w1,"char_server_port") == 0 )
-		char_server_port = (unsigned short)atoi(w2);
-	else if( strcmpi(w1,"char_server_id") == 0 )
-		strncpy(char_server_id, w2, sizeof(char_server_id) - 1);
-	else if( strcmpi(w1,"char_server_pw") == 0 )
-		strncpy(char_server_pw, w2, sizeof(char_server_pw) - 1);
-	else if( strcmpi(w1,"char_server_db") == 0 )
-		strncpy(char_server_db, w2, sizeof(char_server_db) - 1);
-	else if( strcmpi(w1,"char_server_charset") == 0 )
-		strncpy(char_server_charset, w2, sizeof(char_server_charset) - 1);
-	else if( strcmpi(w1,"char_server_keepalive") ==0 )
-		char_server_keepalive = atoi(w2);
-	else
-		return 0;
-
-	return 1;
+	return sqldbs_conninfo_config_read(&char_server_info, "char_server", w1, w2);
 }
 
 /*==========================================
@@ -1237,7 +1216,7 @@ bool chardb_sql_init(void)
 	// DB connection initialized
 	bool is_connect;
 
-	is_connect = sqldbs_connect(&mysql_handle, char_server_ip, char_server_id, char_server_pw, char_server_db, char_server_port, char_server_charset, char_server_keepalive, "CHAR");
+	is_connect = sqldbs_connect_info(&mysql_handle, &char_server_info, "CHAR");
 	if(is_connect == false)
 		return false;
 

--- a/src/common/sqldbs.c
+++ b/src/common/sqldbs.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <string.h>
 
 #include "utils.h"
 #include "db.h"
@@ -758,6 +759,72 @@ void sqldbs_close(struct sqldbs_handle *hd)
  * Ú‘±
  *------------------------------------------
  */
+void sqldbs_conninfo_set_defaults(struct sqldbs_conninfo *info)
+{
+	if(info == NULL)
+		return;
+
+	memset(info, 0, sizeof(*info));
+	info->port = 3306;
+	auriga_strlcpy(info->host, "127.0.0.1", sizeof(info->host));
+	auriga_strlcpy(info->user, "ragnarok", sizeof(info->user));
+	auriga_strlcpy(info->passwd, "ragnarok", sizeof(info->passwd));
+	auriga_strlcpy(info->db, "ragnarok", sizeof(info->db));
+	auriga_strlcpy(info->charset, "", sizeof(info->charset));
+	info->keepalive = 0;
+}
+
+int sqldbs_conninfo_config_read_ex(struct sqldbs_conninfo *info, const char *prefix, const char *db_suffix, const char *w1, const char *w2)
+{
+	char key[64];
+
+	if(info == NULL || prefix == NULL || db_suffix == NULL || w1 == NULL || w2 == NULL)
+		return 0;
+
+	snprintf(key, sizeof(key), "%s_ip", prefix);
+	if(strcmpi(w1, key) == 0) {
+		auriga_strlcpy(info->host, w2, sizeof(info->host));
+		return 1;
+	}
+	snprintf(key, sizeof(key), "%s_port", prefix);
+	if(strcmpi(w1, key) == 0) {
+		info->port = (unsigned short)atoi(w2);
+		return 1;
+	}
+	snprintf(key, sizeof(key), "%s_id", prefix);
+	if(strcmpi(w1, key) == 0) {
+		auriga_strlcpy(info->user, w2, sizeof(info->user));
+		return 1;
+	}
+	snprintf(key, sizeof(key), "%s_pw", prefix);
+	if(strcmpi(w1, key) == 0) {
+		auriga_strlcpy(info->passwd, w2, sizeof(info->passwd));
+		return 1;
+	}
+	snprintf(key, sizeof(key), "%s_%s", prefix, db_suffix);
+	if(strcmpi(w1, key) == 0) {
+		auriga_strlcpy(info->db, w2, sizeof(info->db));
+		return 1;
+	}
+	snprintf(key, sizeof(key), "%s_charset", prefix);
+	if(strcmpi(w1, key) == 0) {
+		auriga_strlcpy(info->charset, w2, sizeof(info->charset));
+		return 1;
+	}
+	snprintf(key, sizeof(key), "%s_keepalive", prefix);
+	if(strcmpi(w1, key) == 0) {
+		info->keepalive = atoi(w2);
+		return 1;
+	}
+
+	return 0;
+}
+
+int sqldbs_conninfo_config_read(struct sqldbs_conninfo *info, const char *prefix, const char *w1, const char *w2)
+{
+	return sqldbs_conninfo_config_read_ex(info, prefix, "db", w1, w2);
+}
+
 bool sqldbs_connect(struct sqldbs_handle *hd, const char *host, const char *user, const char *passwd,
 	const char *db, unsigned short port, const char *charset, int keepalive, const char *tag)
 {
@@ -802,6 +869,15 @@ bool sqldbs_connect(struct sqldbs_handle *hd, const char *host, const char *user
 		hd->tag = (char *)aStrdup(tag);
 
 	return true;
+}
+
+bool sqldbs_connect_info(struct sqldbs_handle *hd, const struct sqldbs_conninfo *info, const char *tag)
+{
+	if(info == NULL)
+		return false;
+
+	return sqldbs_connect(hd, info->host, info->user, info->passwd, info->db,
+		info->port, info->charset, info->keepalive, tag);
 }
 
 #endif /* ifndef TXT_ONLY */

--- a/src/common/sqldbs.h
+++ b/src/common/sqldbs.h
@@ -171,8 +171,23 @@ void sqldbs_stmt_close(struct sqldbs_stmt *st);
 
 // ê⁄ë±
 void sqldbs_close(struct sqldbs_handle *hd);
+struct sqldbs_conninfo {
+	char host[32];
+	unsigned short port;
+	char user[32];
+	char passwd[32];
+	char db[32];
+	char charset[32];
+	int keepalive;
+};
+
+void sqldbs_conninfo_set_defaults(struct sqldbs_conninfo *info);
+int sqldbs_conninfo_config_read(struct sqldbs_conninfo *info, const char *prefix, const char *w1, const char *w2);
+int sqldbs_conninfo_config_read_ex(struct sqldbs_conninfo *info, const char *prefix, const char *db_suffix, const char *w1, const char *w2);
+
 bool sqldbs_connect(struct sqldbs_handle *hd, const char *host, const char *user, const char *passwd,
 	const char *db, unsigned short port, const char *charset, int keepalive, const char *tag);
+bool sqldbs_connect_info(struct sqldbs_handle *hd, const struct sqldbs_conninfo *info, const char *tag);
 
 #endif	// if TXT
 

--- a/src/converter/converter.c
+++ b/src/converter/converter.c
@@ -40,13 +40,25 @@
 
 char converter_conf_filename[256] = "conf/converter_auriga.conf";
 
-char db_server_ip[16] = "127.0.0.1";
+static struct sqldbs_conninfo db_server_info = {
+	"127.0.0.1", 3306, "ragnarok", "ragnarok", "ragnarok", "", 0
+};
+
+/* header compatibility aliases */
 unsigned short db_server_port = 3306;
+char db_server_ip[16] = "127.0.0.1";
 char db_server_id[32] = "ragnarok";
 char db_server_pw[32] = "ragnarok";
 char db_server_logindb[32] = "ragnarok";
-char db_server_charset[32] = "";
-int  db_server_keepalive   = 0;
+
+static void sync_db_server_globals(void)
+{
+	db_server_port = db_server_info.port;
+	auriga_strlcpy(db_server_ip, db_server_info.host, sizeof(db_server_ip));
+	auriga_strlcpy(db_server_id, db_server_info.user, sizeof(db_server_id));
+	auriga_strlcpy(db_server_pw, db_server_info.passwd, sizeof(db_server_pw));
+	auriga_strlcpy(db_server_logindb, db_server_info.db, sizeof(db_server_logindb));
+}
 
 char login_db[1024]            = "login";
 char login_db_account_id[1024] = "account_id";
@@ -142,33 +154,12 @@ static int config_read(const char *cfgName)
 		}
 
 		// add for DB connection
-		else if(strcmpi(w1,"db_server_ip")==0){
-			auriga_strlcpy(db_server_ip, w2, sizeof(db_server_ip));
-			printf("set db_server_ip : %s\n",w2);
-		}
-		else if(strcmpi(w1,"db_server_port")==0){
-			db_server_port = (unsigned short)atoi(w2);
-			printf("set db_server_port : %d\n",db_server_port);
-		}
-		else if(strcmpi(w1,"db_server_id")==0){
-			auriga_strlcpy(db_server_id, w2, sizeof(db_server_id));
-			printf("set db_server_id : %s\n",w2);
-		}
-		else if(strcmpi(w1,"db_server_pw")==0){
-			auriga_strlcpy(db_server_pw, w2, sizeof(db_server_pw));
-			printf("set db_server_pw : %s\n",w2);
-		}
-		else if(strcmpi(w1,"db_server_logindb")==0){
-			auriga_strlcpy(db_server_logindb, w2, sizeof(db_server_logindb));
-			printf("set db_server_logindb : %s\n",w2);
-		}
-		else if(strcmpi(w1,"db_server_charset")==0){
-			auriga_strlcpy(db_server_charset, w2, sizeof(db_server_charset));
-			printf("set db_server_charset : %s\n",w2);
-		}
-		else if(strcmpi(w1,"db_server_keepalive")==0){
-			db_server_keepalive = atoi(w2);
-			printf("set db_server_keepalive : %d\n",db_server_keepalive);
+		else if(sqldbs_conninfo_config_read_ex(&db_server_info, "db_server", "logindb", w1, w2)){
+			sync_db_server_globals();
+			if(strcmpi(w1,"db_server_port")==0)
+				printf("set db_server_port : %d\n", db_server_info.port);
+			else
+				printf("set %s : %s\n", w1, w2);
 		}
 
 		// login SQL DB configuration
@@ -232,9 +223,7 @@ int do_init(int argc,char **argv)
 	config_read(converter_conf_filename);
 
 	// DB connection initialized
-	rc = sqldbs_connect(&mysql_handle,
-		db_server_ip, db_server_id, db_server_pw, db_server_logindb, db_server_port, db_server_charset, db_server_keepalive, "CONVERTER"
-	);
+	rc = sqldbs_connect_info(&mysql_handle, &db_server_info, "CONVERTER");
 	if(rc == false) {
 		printf("FATAL ERROR: sqldbs_connect() failed !!\n");
 		exit(1);

--- a/src/login/sql/account_sql.c
+++ b/src/login/sql/account_sql.c
@@ -33,17 +33,7 @@
 #include "../login.h"
 #include "account_sql.h"
 
-struct sql_config {
-	unsigned short login_server_port;
-	char login_server_ip[32];
-	char login_server_id[32];
-	char login_server_pw[32];
-	char login_server_db[32];
-	char login_server_charset[32];
-	int  login_server_keepalive;
-};
-
-static struct sql_config config;
+static struct sqldbs_conninfo config;
 static struct dbt *account_db = NULL;
 
 /*==========================================
@@ -52,13 +42,7 @@ static struct dbt *account_db = NULL;
  */
 void account_sql_set_default_configvalue(void)
 {
-	config.login_server_port = 3306;
-	auriga_strlcpy(config.login_server_ip, "127.0.0.1", sizeof(config.login_server_ip));
-	auriga_strlcpy(config.login_server_id, "ragnarok", sizeof(config.login_server_id));
-	auriga_strlcpy(config.login_server_pw, "ragnarok", sizeof(config.login_server_pw));
-	auriga_strlcpy(config.login_server_db, "ragnarok", sizeof(config.login_server_db));
-	auriga_strlcpy(config.login_server_charset, "", sizeof(config.login_server_charset));
-	config.login_server_keepalive = 0;
+	sqldbs_conninfo_set_defaults(&config);
 
 	return;
 }
@@ -69,35 +53,22 @@ void account_sql_set_default_configvalue(void)
  */
 int account_sql_config_read_sub(const char *w1, const char *w2)
 {
-	if( strcmpi(w1,"login_server_ip") == 0 )
-		auriga_strlcpy(config.login_server_ip, w2, sizeof(config.login_server_ip));
-	else if( strcmpi(w1,"login_server_port") == 0 )
+	if( strcmpi(w1,"login_server_port") == 0 )
 	{
 		int n = atoi(w2);
 		if( n < 1024 || n > 65535 )
 		{
 			printf("Warning: Invalid login_server_port value: %d. Set to 3306 (default).\n", n);
-			config.login_server_port = 3306; // default
+			config.port = 3306; // default
 		}
 		else
 		{
-			config.login_server_port = (unsigned short)n;
+			config.port = (unsigned short)n;
 		}
+		return 1;
 	}
-	else if( strcmpi(w1, "login_server_id") == 0 )
-		auriga_strlcpy(config.login_server_id, w2, sizeof(config.login_server_id));
-	else if( strcmpi(w1, "login_server_pw") == 0 )
-		auriga_strlcpy(config.login_server_pw, w2, sizeof(config.login_server_pw));
-	else if( strcmpi(w1, "login_server_db") == 0 )
-		auriga_strlcpy(config.login_server_db, w2, sizeof(config.login_server_db));
-	else if( strcmpi(w1, "login_server_charset") == 0 )
-		auriga_strlcpy(config.login_server_charset, w2, sizeof(config.login_server_charset));
-	else if( strcmpi(w1, "login_server_keepalive") == 0 )
-		config.login_server_keepalive = atoi(w2);
-	else
-		return 0;
 
-	return 1;
+	return sqldbs_conninfo_config_read(&config, "login_server", w1, w2);
 }
 
 /*==========================================
@@ -106,10 +77,10 @@ int account_sql_config_read_sub(const char *w1, const char *w2)
  */
 void display_conf_warnings_sql(void)
 {
-	if( config.login_server_pw[0] == '\0' )
+	if( config.passwd[0] == '\0' )
 		printf("SQL SECURITY warning: login_server_pw is not defined (void).\n");
-	else if( strcmp(config.login_server_pw, "ragnarok") == 0 )
-		printf("SQL SECURITY warning: using default login_server_pw ('%s').\n", config.login_server_pw);
+	else if( strcmp(config.passwd, "ragnarok") == 0 )
+		printf("SQL SECURITY warning: using default login_server_pw ('%s').\n", config.passwd);
 
 	return;
 }
@@ -486,7 +457,7 @@ bool account_sql_init(void)
 	bool is_connect;
 
 	// DB connection start
-	is_connect = sqldbs_connect(&mysql_handle, config.login_server_ip, config.login_server_id, config.login_server_pw, config.login_server_db, config.login_server_port, config.login_server_charset, config.login_server_keepalive, "LOGIN");
+	is_connect = sqldbs_connect_info(&mysql_handle, &config, "LOGIN");
 
 	// DB connection error
 	if( is_connect == false )

--- a/src/map/sql/mapreg_sql.c
+++ b/src/map/sql/mapreg_sql.c
@@ -34,13 +34,9 @@
 static struct dbt *mapreg_db;
 static struct dbt *mapregstr_db;
 
-static unsigned short map_server_port = 3306;
-static char map_server_ip[32]      = "127.0.0.1";
-static char map_server_id[32]      = "ragnarok";
-static char map_server_pw[32]      = "ragnarok";
-static char map_server_db[32]      = "ragnarok";
-static char map_server_charset[32] = "";
-static int  map_server_keepalive   = 0;
+static struct sqldbs_conninfo map_server_info = {
+	"127.0.0.1", 3306, "ragnarok", "ragnarok", "ragnarok", "", 0
+};
 
 /*==========================================
  * ê›íËÉtÉ@ÉCÉãì«çû
@@ -48,32 +44,7 @@ static int  map_server_keepalive   = 0;
  */
 int mapreg_sql_config_read_sub(const char *w1, const char *w2)
 {
-	if(strcmpi(w1,"map_server_ip") == 0) {
-		auriga_strlcpy(map_server_ip, w2, sizeof(map_server_ip));
-	}
-	else if(strcmpi(w1,"map_server_port") == 0) {
-		map_server_port = (unsigned short)atoi(w2);
-	}
-	else if(strcmpi(w1,"map_server_id") == 0) {
-		auriga_strlcpy(map_server_id, w2, sizeof(map_server_id));
-	}
-	else if(strcmpi(w1,"map_server_pw") == 0) {
-		auriga_strlcpy(map_server_pw, w2, sizeof(map_server_pw));
-	}
-	else if(strcmpi(w1,"map_server_db") == 0) {
-		auriga_strlcpy(map_server_db, w2, sizeof(map_server_db));
-	}
-	else if(strcmpi(w1,"map_server_charset") == 0) {
-		auriga_strlcpy(map_server_charset, w2, sizeof(map_server_charset));
-	}
-	else if(strcmpi(w1,"map_server_keepalive") == 0) {
-		map_server_keepalive = atoi(w2);
-	}
-	else {
-		return 0;
-	}
-
-	return 1;
+	return sqldbs_conninfo_config_read(&map_server_info, "map_server", w1, w2);
 }
 
 /*==========================================
@@ -247,7 +218,7 @@ bool mapreg_sql_init(void)
 	// DB connection initialized
 	int is_connect;
 
-	is_connect = sqldbs_connect(&mysql_handle, map_server_ip, map_server_id, map_server_pw, map_server_db, map_server_port, map_server_charset, map_server_keepalive, "MAP");
+	is_connect = sqldbs_connect_info(&mysql_handle, &map_server_info, "MAP");
 	if( is_connect == false )
 		return false;
 


### PR DESCRIPTION
## Summary
- Issue #58 Phase 1: login/char/map/converter の SQL 接続設定を `sqldbs_conninfo` に共通化
- conf キー名・接続挙動は変更なし

## Test plan
- [x] SQL ビルドで login/char/map が起動し DB 接続できる
- [ ] `char_server_*` / `login_server_*` / `map_server_*` / `db_server_*` キーが従来どおり効く
