### PR TITLE
refactor: item_sql 抽出と converter の saveitem 同期

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ----------------------------------------
+//1620 [2026/08/10] by Cocoa
+
+・Issue #58: アイテム SQL load/save を item_sql へ抽出し、converter の saveitem を現行スキーマに同期（opt 列欠落を修正）（item_sql.c, item_sql.h, chardb_sql.c, chardb_sql.h, maildb_sql.c, char-converter.c, char-converter.h, Makefile, char-server.vcxproj）
+--------------------------------------------------------------------------------
 //1619 [2026/08/10] by Cocoa
 
 ・Issue #58: SQL 接続設定を sqldbs_conninfo に共通化（login/char/map/converter）（挙動変更なし）（sqldbs.c, sqldbs.h, account_sql.c, chardb_sql.c, mapreg_sql.c, converter.c）

--- a/src/char/sql/chardb_sql.c
+++ b/src/char/sql/chardb_sql.c
@@ -31,6 +31,7 @@
 
 #include "../char.h"
 #include "chardb_sql.h"
+#include "item_sql.h"
 
 static struct dbt *char_db_;
 static struct sqldbs_conninfo char_server_info = {
@@ -46,169 +47,15 @@ int chardb_sql_config_read_sub(const char* w1,const char* w2)
 	return sqldbs_conninfo_config_read(&char_server_info, "char_server", w1, w2);
 }
 
-/*==========================================
- * アイテムのロードの共通関数
- *------------------------------------------
- */
 int chardb_sql_loaditem(struct item *item, int max, int id, int tableswitch)
 {
-	int i = 0;
-	const char *tablename;
-	const char *selectoption;
-	char **sql_row;
-	bool result = false;
-
-	nullpo_retr(-1, item);
-
-	memset(item, 0, sizeof(struct item) * max);
-
-	switch (tableswitch) {
-	case TABLE_NUM_INVENTORY:
-		tablename    = INVENTORY_TABLE;
-		selectoption = "char_id";
-		break;
-	case TABLE_NUM_CART:
-		tablename    = CART_TABLE;
-		selectoption = "char_id";
-		break;
-	case TABLE_NUM_STORAGE:
-		tablename    = STORAGE_TABLE;
-		selectoption = "account_id";
-		break;
-	case TABLE_NUM_GUILD_STORAGE:
-		tablename    = GUILD_STORAGE_TABLE;
-		selectoption = "guild_id";
-		break;
-	default:
-		printf("Invalid table name!\n");
-		return -1;
-	}
-
-	result = sqldbs_query(&mysql_handle,
-		"SELECT `id`, `nameid`, `amount`, `equip`, `identify`, `refine`, `attribute`, "
-		"`card0`, `card1`, `card2`, `card3`, `opt0id`, `opt0val`, `opt1id`, `opt1val`, `opt2id`, `opt2val`, "
-		"`opt3id`, `opt3val`, `opt4id`, `opt4val`, `limit`, `private` FROM `%s` WHERE `%s`='%d'",
-		tablename, selectoption, id
-	);
-	if(result == false)
-		return -1;
-
-	for(i = 0; (sql_row = sqldbs_fetch(&mysql_handle)) && i < max; i++) {
-		item[i].id         = (unsigned int)atoi(sql_row[0]);
-		item[i].nameid     = atoi(sql_row[1]);
-		item[i].amount     = atoi(sql_row[2]);
-		item[i].equip      = (unsigned int)atoi(sql_row[3]);
-		item[i].identify   = atoi(sql_row[4]);
-		item[i].refine     = atoi(sql_row[5]);
-		item[i].attribute  = atoi(sql_row[6]);
-		item[i].card[0]    = atoi(sql_row[7]);
-		item[i].card[1]    = atoi(sql_row[8]);
-		item[i].card[2]    = atoi(sql_row[9]);
-		item[i].card[3]    = atoi(sql_row[10]);
-		item[i].opt[0].id  = atoi(sql_row[11]);
-		item[i].opt[0].val = atoi(sql_row[12]);
-		item[i].opt[1].id  = atoi(sql_row[13]);
-		item[i].opt[1].val = atoi(sql_row[14]);
-		item[i].opt[2].id  = atoi(sql_row[15]);
-		item[i].opt[2].val = atoi(sql_row[16]);
-		item[i].opt[3].id  = atoi(sql_row[17]);
-		item[i].opt[3].val = atoi(sql_row[18]);
-		item[i].opt[4].id  = atoi(sql_row[19]);
-		item[i].opt[4].val = atoi(sql_row[20]);
-		item[i].limit      = (unsigned int)atoi(sql_row[21]);
-		item[i].private_   = atoi(sql_row[22]);
-	}
-	sqldbs_free_result(&mysql_handle);
-
-	return i;
+	return item_sql_loaditem(item, max, id, tableswitch);
 }
 
-/*==========================================
- * アイテムのセーブの共通関数
- *------------------------------------------
- */
 bool chardb_sql_saveitem(struct item *item, int max, int id, int tableswitch)
 {
-	const char *tablename;
-	const char *selectoption;
-	char *p, tmp_sql[65536 * 2];
-	char sep = ' ';
-	bool result = false;
-
-	nullpo_retr(false, item);
-
-	switch (tableswitch) {
-	case TABLE_NUM_INVENTORY:
-		tablename    = INVENTORY_TABLE;
-		selectoption = "char_id";
-		break;
-	case TABLE_NUM_CART:
-		tablename    = CART_TABLE;
-		selectoption = "char_id";
-		break;
-	case TABLE_NUM_STORAGE:
-		tablename    = STORAGE_TABLE;
-		selectoption = "account_id";
-		break;
-	case TABLE_NUM_GUILD_STORAGE:
-		tablename    = GUILD_STORAGE_TABLE;
-		selectoption = "guild_id";
-		break;
-	default:
-		printf("Invalid table name!\n");
-		return false;
-	}
-
-	if( sqldbs_transaction_start(&mysql_handle) == false )
-		return false;
-
-	// try
-	do
-	{
-		int i;
-
-		// delete
-		if( sqldbs_query(&mysql_handle, "DELETE FROM `%s` WHERE `%s`='%d'", tablename, selectoption, id) == false)
-			break;
-
-		p  = tmp_sql;
-		p += sprintf(
-			p,"INSERT INTO `%s`(`id`, `%s`, `nameid`, `amount`, `equip`, `identify`, `refine`, "
-			"`attribute`, `card0`, `card1`, `card2`, `card3`, `opt0id`, `opt0val`, `opt1id`, `opt1val`, `opt2id`, `opt2val`, "
-			"`opt3id`, `opt3val`, `opt4id`, `opt4val`, `limit`, `private`) VALUES",tablename,selectoption
-		);
-
-		for(i = 0; i < max; i++) {
-			if(item[i].nameid) {
-				p += sprintf(
-					p,"%c('%u','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%u',%d)",
-					sep,item[i].id,id,item[i].nameid,item[i].amount,item[i].equip,item[i].identify,
-					item[i].refine,item[i].attribute,item[i].card[0],item[i].card[1],item[i].card[2],item[i].card[3],
-					item[i].opt[0].id,item[i].opt[0].val,item[i].opt[1].id,item[i].opt[1].val,item[i].opt[2].id,item[i].opt[2].val,
-					item[i].opt[3].id,item[i].opt[3].val,item[i].opt[4].id,item[i].opt[4].val,item[i].limit,item[i].private_
-				);
-				sep = ',';
-			}
-		}
-
-		if(sep == ',') {
-			if( sqldbs_simplequery(&mysql_handle, tmp_sql) == false )
-				break;
-		}
-
-		// success
-		result = true;
-	} while(0);
-
-	sqldbs_transaction_end(&mysql_handle, result);
-
-	return result;
+	return item_sql_saveitem(item, max, id, tableswitch);
 }
-
-/*==========================================
- * 同期
- *------------------------------------------
- */
 void chardb_sql_sync(void)
 {
 	// nothing to do

--- a/src/char/sql/chardb_sql.h
+++ b/src/char/sql/chardb_sql.h
@@ -26,15 +26,9 @@
 #include "utils.h"
 #include "../char.h"
 
-// 更新定義
-enum {
-	TABLE_NUM_INVENTORY,
-	TABLE_NUM_CART,
-	TABLE_NUM_STORAGE,
-	TABLE_NUM_GUILD_STORAGE,
-};
+#include "item_sql.h"
 
-// プロトタイプ宣言
+/* compatibility wrappers (implemented in chardb_sql.c) */
 int chardb_sql_loaditem(struct item *item, int max, int id, int tableswitch);
 bool chardb_sql_saveitem(struct item *item, int max, int id, int tableswitch);
 const struct mmo_chardata* chardb_sql_make(int account_id, const unsigned char *name, short str, short agi, short vit, short int_, short dex, short luk, short hair_color, short hair, short job, char sex, unsigned char slot, int *flag);

--- a/src/char/sql/item_sql.c
+++ b/src/char/sql/item_sql.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2002-2020  Auriga
+ *
+ * This file is part of Auriga.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef TXT_ONLY
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mmo.h"
+#include "sqldbs.h"
+#include "nullpo.h"
+
+#include "item_sql.h"
+
+/*==========================================
+ * Map one SQL row to struct item
+ *------------------------------------------
+ */
+void item_sql_loadrow(struct item *item, char **sql_row, int with_private)
+{
+	nullpo_retv(item);
+	nullpo_retv(sql_row);
+
+	item->id         = (unsigned int)atoi(sql_row[0]);
+	item->nameid     = atoi(sql_row[1]);
+	item->amount     = atoi(sql_row[2]);
+	item->equip      = (unsigned int)atoi(sql_row[3]);
+	item->identify   = atoi(sql_row[4]);
+	item->refine     = atoi(sql_row[5]);
+	item->attribute  = atoi(sql_row[6]);
+	item->card[0]    = atoi(sql_row[7]);
+	item->card[1]    = atoi(sql_row[8]);
+	item->card[2]    = atoi(sql_row[9]);
+	item->card[3]    = atoi(sql_row[10]);
+	item->opt[0].id  = atoi(sql_row[11]);
+	item->opt[0].val = atoi(sql_row[12]);
+	item->opt[1].id  = atoi(sql_row[13]);
+	item->opt[1].val = atoi(sql_row[14]);
+	item->opt[2].id  = atoi(sql_row[15]);
+	item->opt[2].val = atoi(sql_row[16]);
+	item->opt[3].id  = atoi(sql_row[17]);
+	item->opt[3].val = atoi(sql_row[18]);
+	item->opt[4].id  = atoi(sql_row[19]);
+	item->opt[4].val = atoi(sql_row[20]);
+	item->limit      = (unsigned int)atoi(sql_row[21]);
+	if(with_private)
+		item->private_ = atoi(sql_row[22]);
+	else
+		item->private_ = 0;
+}
+
+/*==========================================
+ * Common item load (inventory/cart/storage)
+ *------------------------------------------
+ */
+int item_sql_loaditem(struct item *item, int max, int id, int tableswitch)
+{
+	int i = 0;
+	const char *tablename;
+	const char *selectoption;
+	char **sql_row;
+	bool result = false;
+
+	nullpo_retr(-1, item);
+
+	memset(item, 0, sizeof(struct item) * max);
+
+	switch (tableswitch) {
+	case TABLE_NUM_INVENTORY:
+		tablename    = INVENTORY_TABLE;
+		selectoption = "char_id";
+		break;
+	case TABLE_NUM_CART:
+		tablename    = CART_TABLE;
+		selectoption = "char_id";
+		break;
+	case TABLE_NUM_STORAGE:
+		tablename    = STORAGE_TABLE;
+		selectoption = "account_id";
+		break;
+	case TABLE_NUM_GUILD_STORAGE:
+		tablename    = GUILD_STORAGE_TABLE;
+		selectoption = "guild_id";
+		break;
+	default:
+		printf("Invalid table name!\n");
+		return -1;
+	}
+
+	result = sqldbs_query(&mysql_handle,
+		"SELECT " ITEM_SQL_COLUMNS_PRIVATE " FROM `%s` WHERE `%s`='%d'",
+		tablename, selectoption, id
+	);
+	if(result == false)
+		return -1;
+
+	for(i = 0; (sql_row = sqldbs_fetch(&mysql_handle)) && i < max; i++) {
+		item_sql_loadrow(&item[i], sql_row, 1);
+	}
+	sqldbs_free_result(&mysql_handle);
+
+	return i;
+}
+
+/*==========================================
+ * Common item save (inventory/cart/storage)
+ *------------------------------------------
+ */
+bool item_sql_saveitem(struct item *item, int max, int id, int tableswitch)
+{
+	const char *tablename;
+	const char *selectoption;
+	char *p, tmp_sql[65536 * 2];
+	char sep = ' ';
+	bool result = false;
+
+	nullpo_retr(false, item);
+
+	switch (tableswitch) {
+	case TABLE_NUM_INVENTORY:
+		tablename    = INVENTORY_TABLE;
+		selectoption = "char_id";
+		break;
+	case TABLE_NUM_CART:
+		tablename    = CART_TABLE;
+		selectoption = "char_id";
+		break;
+	case TABLE_NUM_STORAGE:
+		tablename    = STORAGE_TABLE;
+		selectoption = "account_id";
+		break;
+	case TABLE_NUM_GUILD_STORAGE:
+		tablename    = GUILD_STORAGE_TABLE;
+		selectoption = "guild_id";
+		break;
+	default:
+		printf("Invalid table name!\n");
+		return false;
+	}
+
+	if( sqldbs_transaction_start(&mysql_handle) == false )
+		return false;
+
+	/* try */
+	do
+	{
+		int i;
+
+		/* delete */
+		if( sqldbs_query(&mysql_handle, "DELETE FROM `%s` WHERE `%s`='%d'", tablename, selectoption, id) == false)
+			break;
+
+		p  = tmp_sql;
+		p += sprintf(
+			p,"INSERT INTO `%s`(`id`, `%s`, `nameid`, `amount`, `equip`, `identify`, `refine`, "
+			"`attribute`, `card0`, `card1`, `card2`, `card3`, `opt0id`, `opt0val`, `opt1id`, `opt1val`, `opt2id`, `opt2val`, "
+			"`opt3id`, `opt3val`, `opt4id`, `opt4val`, `limit`, `private`) VALUES",tablename,selectoption
+		);
+
+		for(i = 0; i < max; i++) {
+			if(item[i].nameid) {
+				p += sprintf(
+					p,"%c('%u','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%u',%d)",
+					sep,item[i].id,id,item[i].nameid,item[i].amount,item[i].equip,item[i].identify,
+					item[i].refine,item[i].attribute,item[i].card[0],item[i].card[1],item[i].card[2],item[i].card[3],
+					item[i].opt[0].id,item[i].opt[0].val,item[i].opt[1].id,item[i].opt[1].val,item[i].opt[2].id,item[i].opt[2].val,
+					item[i].opt[3].id,item[i].opt[3].val,item[i].opt[4].id,item[i].opt[4].val,item[i].limit,item[i].private_
+				);
+				sep = ',';
+			}
+		}
+
+		if(sep == ',') {
+			if( sqldbs_simplequery(&mysql_handle, tmp_sql) == false )
+				break;
+		}
+
+		/* success */
+		result = true;
+	} while(0);
+
+	sqldbs_transaction_end(&mysql_handle, result);
+
+	return result;
+}
+
+#endif /* TXT_ONLY */

--- a/src/char/sql/item_sql.h
+++ b/src/char/sql/item_sql.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2002-2020  Auriga
+ *
+ * This file is part of Auriga.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef _ITEM_SQL_H_
+#define _ITEM_SQL_H_
+
+#ifndef TXT_ONLY
+
+#include "mmo.h"
+
+/* table selector for inventory / cart / storage / guild_storage */
+enum {
+	TABLE_NUM_INVENTORY,
+	TABLE_NUM_CART,
+	TABLE_NUM_STORAGE,
+	TABLE_NUM_GUILD_STORAGE,
+};
+
+/* SELECT column list: id .. limit [, private] */
+#define ITEM_SQL_COLUMNS \
+	"`id`, `nameid`, `amount`, `equip`, `identify`, `refine`, `attribute`, " \
+	"`card0`, `card1`, `card2`, `card3`, `opt0id`, `opt0val`, `opt1id`, `opt1val`, `opt2id`, `opt2val`, " \
+	"`opt3id`, `opt3val`, `opt4id`, `opt4val`, `limit`"
+#define ITEM_SQL_COLUMNS_PRIVATE ITEM_SQL_COLUMNS ", `private`"
+
+int item_sql_loaditem(struct item *item, int max, int id, int tableswitch);
+bool item_sql_saveitem(struct item *item, int max, int id, int tableswitch);
+
+/* Map sql_row[0..] -> item. with_private: also read private_ from next column. */
+void item_sql_loadrow(struct item *item, char **sql_row, int with_private);
+
+#endif /* TXT_ONLY */
+
+#endif /* _ITEM_SQL_H_ */

--- a/src/char/sql/maildb_sql.c
+++ b/src/char/sql/maildb_sql.c
@@ -32,6 +32,7 @@
 
 #include "petdb_sql.h"
 #include "maildb_sql.h"
+#include "item_sql.h"
 
 static struct dbt *mail_db = NULL;
 
@@ -128,10 +129,7 @@ bool maildb_sql_read_mail(int char_id, const struct mail *m, struct mail_data md
 
 	result = sqldbs_query(&mysql_handle,
 		"SELECT `number`, `read`, `send_name`, `receive_name`, `title`, `times`, `size`, `body`, `zeny`, "
-		"`id`, `nameid`, `amount`, `equip`, `identify`, `refine`, `attribute`, "
-		"`card0`, `card1`, `card2`, `card3`, "
-		"`opt0id`, `opt0val`, `opt1id`, `opt1val`, `opt2id`, `opt2val`, "
-		"`opt3id`, `opt3val`, `opt4id`, `opt4val`, `limit`"
+		ITEM_SQL_COLUMNS
 		" FROM `" MAIL_DATA_TABLE "` WHERE `char_id` = '%d' ORDER BY `number`", char_id
 	);
 	if(result == false)
@@ -162,29 +160,8 @@ bool maildb_sql_read_mail(int char_id, const struct mail *m, struct mail_data md
 		}
 		md[i].body_size = n;
 
-		md[i].zeny            = atoi(sql_row[8]);
-		md[i].item.id         = (unsigned int)atoi(sql_row[9]);
-		md[i].item.nameid     = atoi(sql_row[10]);
-		md[i].item.amount     = atoi(sql_row[11]);
-		md[i].item.equip      = (unsigned int)atoi(sql_row[12]);
-		md[i].item.identify   = atoi(sql_row[13]);
-		md[i].item.refine     = atoi(sql_row[14]);
-		md[i].item.attribute  = atoi(sql_row[15]);
-		md[i].item.card[0]    = atoi(sql_row[16]);
-		md[i].item.card[1]    = atoi(sql_row[17]);
-		md[i].item.card[2]    = atoi(sql_row[18]);
-		md[i].item.card[3]    = atoi(sql_row[19]);
-		md[i].item.opt[0].id  = atoi(sql_row[20]);
-		md[i].item.opt[0].val = atoi(sql_row[21]);
-		md[i].item.opt[1].id  = atoi(sql_row[22]);
-		md[i].item.opt[1].val = atoi(sql_row[23]);
-		md[i].item.opt[2].id  = atoi(sql_row[24]);
-		md[i].item.opt[2].val = atoi(sql_row[25]);
-		md[i].item.opt[3].id  = atoi(sql_row[26]);
-		md[i].item.opt[3].val = atoi(sql_row[27]);
-		md[i].item.opt[4].id  = atoi(sql_row[28]);
-		md[i].item.opt[4].val = atoi(sql_row[29]);
-		md[i].item.limit      = (unsigned int)atoi(sql_row[30]);
+		md[i].zeny = atoi(sql_row[8]);
+		item_sql_loadrow(&md[i].item, &sql_row[9], 0);
 	}
 	sqldbs_free_result(&mysql_handle);
 

--- a/src/converter/Makefile
+++ b/src/converter/Makefile
@@ -11,6 +11,7 @@ COMMON_SRC += $(shell ls ../common/zlib/*.c)
 endif
 
 CONVERTER_SRC = $(shell ls *.c)
+CONVERTER_SRC += ../char/sql/item_sql.c
 
 txt-converter: $(CONVERTER_SRC:.c=.o) $(COMMON_SRC:.c=.o)
 	$(CC) -o ../../$@ $> $(LIBS)

--- a/src/converter/char-converter.c
+++ b/src/converter/char-converter.c
@@ -35,64 +35,8 @@
 #include "converter.h"
 #include "utils.h"
 #include "char-converter.h"
+#include "../char/sql/item_sql.h"
 
-
-static int char_sql_saveitem(struct item *item, int max, int id, int tableswitch)
-{
-	int i;
-	const char *tablename;
-	const char *selectoption;
-	char *p, tmp_sql[65536 * 2];
-	char sep = ' ';
-
-	switch (tableswitch) {
-	case TABLE_INVENTORY:
-		tablename    = "inventory";
-		selectoption = "char_id";
-		break;
-	case TABLE_CART:
-		tablename    = "cart_inventory";
-		selectoption = "char_id";
-		break;
-	case TABLE_STORAGE:
-		tablename    = "storage";
-		selectoption = "account_id";
-		break;
-	case TABLE_GUILD_STORAGE:
-		tablename    = "guild_storage";
-		selectoption = "guild_id";
-		break;
-	default:
-		printf("Invalid table name!\n");
-		return 1;
-	}
-
-	// delete
-	sqldbs_query(&mysql_handle, "DELETE FROM `%s` WHERE `%s`='%d'", tablename, selectoption, id);
-
-	p  = tmp_sql;
-	p += sprintf(
-		p,"INSERT INTO `%s`(`id`, `%s`, `nameid`, `amount`, `equip`, `identify`, `refine`, "
-		"`attribute`, `card0`, `card1`, `card2`, `card3`, `limit`, `private`) VALUES",tablename,selectoption
-	);
-
-	for(i = 0 ; i < max ; i++) {
-		if(item[i].nameid) {
-			p += sprintf(
-				p,"%c('%u','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%d','%u','%d')",
-				sep,item[i].id,id,item[i].nameid,item[i].amount,item[i].equip,item[i].identify,
-				item[i].refine,item[i].attribute,item[i].card[0],item[i].card[1],
-				item[i].card[2],item[i].card[3],item[i].limit,item[i].private_
-			);
-			sep = ',';
-		}
-	}
-	if(sep == ',') {
-		sqldbs_simplequery(&mysql_handle, tmp_sql);
-	}
-
-	return 0;
-}
 
 // キャラクターデータを文字列から変換
 static int mmo_char_fromstr(char *str, struct mmo_chardata *p)
@@ -397,10 +341,10 @@ static int mmo_char_tosql(int char_id, struct mmo_charstatus *st)
 	}
 
 	// inventory
-	char_sql_saveitem(st->inventory, MAX_INVENTORY, st->char_id, TABLE_INVENTORY);
+	item_sql_saveitem(st->inventory, MAX_INVENTORY, st->char_id, TABLE_NUM_INVENTORY);
 
 	// cart
-	char_sql_saveitem(st->cart, MAX_CART, st->char_id, TABLE_CART);
+	item_sql_saveitem(st->cart, MAX_CART, st->char_id, TABLE_NUM_CART);
 
 	// skill
 	sqldbs_query(&mysql_handle, "DELETE FROM `skill` WHERE `char_id`='%d'", char_id);
@@ -1257,7 +1201,7 @@ int char_convert(void)
 				s.account_id = tmp_int[0];
 			}
 			if(s.account_id > 0 && storage_fromstr(line,&s) == 0) {
-				char_sql_saveitem(s.store_item,MAX_STORAGE,s.account_id,TABLE_STORAGE);
+				item_sql_saveitem(s.store_item,MAX_STORAGE,s.account_id,TABLE_NUM_STORAGE);
 			} else {
 				printf("storage: broken data [%s] line %d\n",storage_txt,c);
 			}
@@ -1379,7 +1323,7 @@ int char_convert(void)
 			if(sscanf(line,"%d,%d",&tmp_int[0],&tmp_int[1]) == 2)
 				gs.guild_id = tmp_int[0];
 			if(gs.guild_id > 0 && gstorage_fromstr(line,&gs) == 0) {
-				char_sql_saveitem(gs.store_item,MAX_GUILD_STORAGE,gs.guild_id,TABLE_GUILD_STORAGE);
+				item_sql_saveitem(gs.store_item,MAX_GUILD_STORAGE,gs.guild_id,TABLE_NUM_GUILD_STORAGE);
 			} else {
 				printf("gstorage: broken data [%s] line %d\n",guild_storage_txt,c);
 			}

--- a/src/converter/char-converter.h
+++ b/src/converter/char-converter.h
@@ -32,11 +32,4 @@ struct mmo_chardata {
 	struct registry reg;
 };
 
-enum {
-	TABLE_INVENTORY,
-	TABLE_CART,
-	TABLE_STORAGE,
-	TABLE_GUILD_STORAGE,
-};
-
 #endif /* _CHAR_CONVERTER_H_ */

--- a/vcproj/char-server.vcxproj
+++ b/vcproj/char-server.vcxproj
@@ -120,6 +120,7 @@
     <ClInclude Include="..\src\char\sql\achievedb_sql.h" />
     <ClInclude Include="..\src\char\sql\accregdb_sql.h" />
     <ClInclude Include="..\src\char\sql\chardb_sql.h" />
+    <ClInclude Include="..\src\char\sql\item_sql.h" />
     <ClInclude Include="..\src\char\sql\charlog_sql.h" />
     <ClInclude Include="..\src\char\sql\elemdb_sql.h" />
     <ClInclude Include="..\src\char\sql\guilddb_sql.h" />
@@ -176,6 +177,7 @@
     <ClCompile Include="..\src\char\sql\achievedb_sql.c" />
     <ClCompile Include="..\src\char\sql\accregdb_sql.c" />
     <ClCompile Include="..\src\char\sql\chardb_sql.c" />
+    <ClCompile Include="..\src\char\sql\item_sql.c" />
     <ClCompile Include="..\src\char\sql\charlog_sql.c" />
     <ClCompile Include="..\src\char\sql\elemdb_sql.c" />
     <ClCompile Include="..\src\char\sql\guilddb_sql.c" />


### PR DESCRIPTION
## Summary
- Issue #58 Phase 2: inventory/cart/storage の item load/save を `item_sql` へ抽出
- converter の古い `char_sql_saveitem` を廃止し現行スキーマ（opt 列含む）に同期
- mail は `item_sql_loadrow` で列マッピングのみ共有

## Notes
- **converter の挙動変更**: トランザクションあり・opt 列ありに揃えました。opt 未対応の古い DB スキーマでは converter が失敗します。現行 `sql-files` 定義への追従が前提です。
- `vcproj/char-server.vcxproj.filters` に `item_sql` を追加済み

## Test plan
- [ ] SQL ビルドでキャラ/倉庫セーブが従来どおり動く
- [ ] converter の txt→SQL で inventory 等に opt 列が入る
- [ ] `sql-files` の該当テーブル定義と INSERT 列が一致する