### PR TITLE
refactor: txt ジャーナル配線を journal_config/setup に共通化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ----------------------------------------
+//1621 [2026/08/10] by Cocoa
+
+・Issue #58: txt ジャーナル配線を journal_config / journal_setup / journal_recreate に共通化（挙動変更なし）（journal.c, journal.h, *_txt.c, guilddb_txt.h, int_guild.c, doc/journal.txt）
+--------------------------------------------------------------------------------
 //1618 [2026/08/10] by Cocoa
 
 ・Issue #57: status_calc_pc / status_change_start / status_change_end をリファクタ。L_RECALC 再入を status_calc_ctrl で Unity 固定し、calc を phase 分割のうえ status_calc_pc.c へ、start/end を別 TU へ分離。SC ハンドラテーブルを導入し代表バッチを移行（挙動変更なし）（status.c, status_calc_ctrl.c, status_calc_ctrl.h, status_calc_pc.c, status_change_start.c, status_change_end.c, status_change_handlers.c, status_internal.h, tests/, map-server.vcxproj）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ----------------------------------------
+//1622 [2026/08/10] by Cocoa
+
+・fix: gstoragedb_txt_save が個人倉庫ジャーナルへ書いていたのを guild_storage_journal へ修正（#93 と同内容・journal_config 化後の識別子）（storagedb_txt.c）
+----------------------------------------
 //1621 [2026/08/10] by Cocoa
 
 ・Issue #58: txt ジャーナル配線を journal_config / journal_setup / journal_recreate に共通化（挙動変更なし）（journal.c, journal.h, *_txt.c, guilddb_txt.h, int_guild.c, doc/journal.txt）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,71 +1,85 @@
 ----------------------------------------
-//1622 [2026/08/10] by Cocoa
-
-・fix: gstoragedb_txt_save が個人倉庫ジャーナルへ書いていたのを guild_storage_journal へ修正（#93 と同内容・journal_config 化後の識別子）（storagedb_txt.c）
-----------------------------------------
 //1621 [2026/08/10] by Cocoa
 
 ・Issue #58: txt ジャーナル配線を journal_config / journal_setup / journal_recreate に共通化（挙動変更なし）（journal.c, journal.h, *_txt.c, guilddb_txt.h, int_guild.c, doc/journal.txt）
+
+・fix: gstoragedb_txt_save が個人倉庫ジャーナルへ書いていたのを guild_storage_journal へ修正（#93 と同内容・journal_config 化後の識別子）（storagedb_txt.c）
+
 --------------------------------------------------------------------------------
 //1618 [2026/08/10] by Cocoa
 
 ・Issue #57: status_calc_pc / status_change_start / status_change_end をリファクタ。L_RECALC 再入を status_calc_ctrl で Unity 固定し、calc を phase 分割のうえ status_calc_pc.c へ、start/end を別 TU へ分離。SC ハンドラテーブルを導入し代表バッチを移行（挙動変更なし）（status.c, status_calc_ctrl.c, status_calc_ctrl.h, status_calc_pc.c, status_change_start.c, status_change_end.c, status_change_handlers.c, status_internal.h, tests/, map-server.vcxproj）
+
 ----------------------------------------
 //1617 [2026/08/09] by Cocoa
 
 ・Unity によるユニットテスト基盤を追加。`make test` / `tests\vc_test.bat` と GitHub Actions（Linux GCC/Clang・macOS Clang・Windows MSVC 2022/2026）で実行可能に。md5calc / HMAC-MD5、utils、linkdb / numdb / strdb / csvdb、nullpo、DIFF_TICK 等をカバー（挙動変更なし）（third_party/unity/, tests/, Makefile, .github/workflows/unit-test-*.yml, doc/unit_test.txt）
+
 ----------------------------------------
 //1616 [2026/08/09] by Cocoa
 
 ・script.c の未使用ヘッダー削除と余分な空行整理。buildin 分割後に残っていた #include とセクション見出し前の二重空行を除去（挙動変更なし）（script.c）
+
 ----------------------------------------
 //1615 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第12弾）: 残り misc 系（time / map util / string / sql / unit / achievement 等）を buildin_misc.c へ分離。エンジン核（goto/set/array/jump_zero）は script.c に残置。getmapxy/sqlquery の str_buf 直参照を get_str() に置換。script_sql_enabled() / mysql_handle_script を script_internal.h 経由で共有（挙動変更なし）（script.c, buildin_misc.c, script_internal.h, map-server.vcxproj）
+
 ----------------------------------------
 //1614 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第11弾）: memorial dungeon 系を buildin_md.c へ分離（挙動変更なし）（script.c, buildin_md.c, map-server.vcxproj）
+
 ----------------------------------------
 //1613 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第10弾）: misceffect / soundeffect / musiceffect 系を buildin_effect.c へ分離（挙動変更なし）（script.c, buildin_effect.c, map-server.vcxproj）
+
 ----------------------------------------
 //1612 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第9弾）: quest 系を buildin_quest.c へ分離（挙動変更なし）（script.c, buildin_quest.c, map-server.vcxproj）
+
 ----------------------------------------
 //1611 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第8弾）: CSV 系命令を buildin_csv.c へ分離。csvinit/final・getarraysize を script_internal.h 経由で共有。csvreadarray/csvwritearray の str_buf 直参照を get_str() に置換（挙動変更なし）（script.c, buildin_csv.c, script_internal.h, map-server.vcxproj）
+
 ----------------------------------------
 //1610 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第7弾）: monster / guardian / mob skill 系を buildin_mob.c へ分離。getmapmoblist の str_buf 直参照を get_str() に置換（挙動変更なし）（script.c, buildin_mob.c, map-server.vcxproj）
+
 ----------------------------------------
 //1609 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第6弾）: pet / homunculus / mercenary 系を buildin_pet.c へ分離（挙動変更なし）（script.c, buildin_pet.c, map-server.vcxproj）
+
 ----------------------------------------
 //1608 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第5弾）: dialog / UI 系を buildin_dialog.c、PC / status 系を buildin_pc.c へ分離（挙動変更なし）（script.c, buildin_dialog.c, buildin_pc.c, map-server.vcxproj）
+
 ----------------------------------------
 //1607 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第4弾）: party / guild / agit・castle / marriage・adoption 等を buildin_party.c へ分離（挙動変更なし）（script.c, buildin_party.c, map-server.vcxproj）
+
 ----------------------------------------
 //1606 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第3弾）: NPC 制御 / タイマー / waitingroom / npcskill・walk 等を buildin_npc.c へ分離。sleep/awake 用 API を script_internal.h 経由で共有（挙動変更なし）（script.c, buildin_npc.c, script_internal.h, map-server.vcxproj）
+
 ----------------------------------------
 //1605 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第2弾）: item / 装備 / 精錬 / カード系命令を buildin_item.c へ分離。refine_posword を script_internal.h 経由で共有（挙動変更なし）（script.c, buildin_item.c, script_internal.h, map-server.vcxproj）
+
 ----------------------------------------
 //1604 [2026/08/09] by Cocoa
 
 ・script.c のビルドイン命令分割（第1弾）: map 系命令（warp / announce / mapflag / pvp・gvg 等）を buildin_map.c へ分離。共有ヘルパーを script_internal.h 経由で公開（挙動変更なし）（script.c, buildin_map.c, script_internal.h, map-server.vcxproj）
+
 ----------------------------------------
 //1603 [2026/08/09] by Cocoa
 

--- a/doc/journal.txt
+++ b/doc/journal.txt
@@ -111,3 +111,13 @@ journal.c
 		よいと思われます。
 		データによってはジャーナルのファイルサイズに大きく影響します。
 
+==========================================================================
+・実装メモ（共通ヘルパ）
+--------------------------------------------------------------------------
+
+・各 txt モジュールの journal_enable / journal_file / journal_cache_interval
+　設定キーは journal_config_read() で共通読み込みする。
+・起動時の load / roll-forward / create は journal_setup()
+　（mapreg は journal_setup_with_convert()）、
+　txt 同期後のジャーナル再作成は journal_recreate() を利用する。
+・セーブ形式および conf キー名は従来どおり。

--- a/src/char/int_guild.c
+++ b/src/char/int_guild.c
@@ -1078,7 +1078,7 @@ int mapif_parse_GuildCastleDataSave(int fd,int castle_id,int idx,int value)
 			return 0;
 	}
 #if defined(TXT_ONLY) && defined(TXT_JOURNAL)
-	if( guildcastle_journal_enable )
+	if( guildcastle_journal_cfg.enable )
 		journal_write( &guildcastle_journal, gc->castle_id, gc );
 #endif
 	return mapif_guild_castle_datasave(gc->castle_id,idx,value);

--- a/src/char/txt/accregdb_txt.c
+++ b/src/char/txt/accregdb_txt.c
@@ -38,10 +38,8 @@ static struct dbt *accreg_db = NULL;
 static char accreg_txt[1024] = "save/accreg.txt";
 
 #ifdef TXT_JOURNAL
-static int accreg_journal_enable = 1;
+static struct journal_config accreg_journal_cfg = { 1, "./save/accreg.journal", 1000 };
 static struct journal accreg_journal;
-static char accreg_journal_file[1024] = "./save/accreg.journal";
-static int accreg_journal_cache = 1000;
 #endif
 
 /*==========================================
@@ -54,14 +52,7 @@ int accregdb_txt_config_read_sub(const char *w1,const char *w2)
 		strncpy(accreg_txt, w2, sizeof(accreg_txt) - 1);
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"accreg_journal_enable")==0){
-		accreg_journal_enable = atoi( w2 );
-	}
-	else if(strcmpi(w1,"accreg_journal_file")==0){
-		strncpy( accreg_journal_file, w2, sizeof(accreg_journal_file) - 1 );
-	}
-	else if(strcmpi(w1,"accreg_journal_cache_interval")==0){
-		accreg_journal_cache = atoi( w2 );
+	else if(journal_config_read(&accreg_journal_cfg, "accreg_journal", w1, w2)) {
 	}
 #endif
 	else {
@@ -193,25 +184,11 @@ static bool accregdb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( accreg_journal_enable )
+	if( journal_setup( &accreg_journal, &accreg_journal_cfg, sizeof(struct accreg), accregdb_journal_rollforward, "inter: accreg_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &accreg_journal, sizeof(struct accreg), accreg_journal_file ) )
-		{
-			int c = journal_rollforward( &accreg_journal, accregdb_journal_rollforward );
-
-			printf("inter: accreg_journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			accregdb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &accreg_journal );
-			journal_create( &accreg_journal, sizeof(struct accreg), accreg_journal_cache, accreg_journal_file );
-		}
+		accregdb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -251,11 +228,10 @@ int accregdb_txt_sync(void)
 	lock_fclose(fp, accreg_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( accreg_journal_enable )
+	if( accreg_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &accreg_journal );
-		journal_create( &accreg_journal, sizeof(struct accreg), accreg_journal_cache, accreg_journal_file );
+		journal_recreate( &accreg_journal, &accreg_journal_cfg, sizeof(struct accreg) );
 	}
 #endif
 
@@ -289,7 +265,7 @@ bool accregdb_txt_save(struct accreg *reg2)
 	memcpy(reg1, reg2, sizeof(struct accreg));
 
 #ifdef TXT_JOURNAL
-	if( accreg_journal_enable )
+	if( accreg_journal_cfg.enable )
 		journal_write( &accreg_journal, reg2->account_id, reg2 );
 #endif
 
@@ -315,7 +291,7 @@ void accregdb_txt_final(void)
 		numdb_final(accreg_db, accregdb_txt_final_sub);
 
 #ifdef TXT_JOURNAL
-	if( accreg_journal_enable )
+	if( accreg_journal_cfg.enable )
 		journal_final( &accreg_journal );
 #endif
 }

--- a/src/char/txt/achievedb_txt.c
+++ b/src/char/txt/achievedb_txt.c
@@ -36,10 +36,8 @@ static char achieve_txt[1024] = "save/achieve.txt";
 static struct dbt *achieve_db = NULL;
 
 #ifdef TXT_JOURNAL
-static int achieve_journal_enable = 1;
+static struct journal_config achieve_journal_cfg = { 1, "./save/achieve.journal", 1000 };
 static struct journal achieve_journal;
-static char achieve_journal_file[1024] = "./save/achieve.journal";
-static int achieve_journal_cache = 1000;
 #endif
 
 /*==========================================
@@ -52,14 +50,7 @@ int achievedb_txt_config_read_sub(const char *w1, const char *w2)
 		auriga_strlcpy(achieve_txt, w2, sizeof(achieve_txt));
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"achieve_journal_enable")==0) {
-		achieve_journal_enable = atoi(w2);
-	}
-	else if(strcmpi(w1,"achieve_journal_file")==0) {
-		auriga_strlcpy(achieve_journal_file, w2, sizeof(achieve_journal_file));
-	}
-	else if(strcmpi(w1,"achieve_journal_cache_interval")==0) {
-		achieve_journal_cache = atoi(w2);
+	else if(journal_config_read(&achieve_journal_cfg, "achieve_journal", w1, w2)) {
 	}
 #endif
 	else {
@@ -223,25 +214,11 @@ static bool achievedb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( achieve_journal_enable )
+	if( journal_setup( &achieve_journal, &achieve_journal_cfg, sizeof(struct achieve), achieve_journal_rollforward, "inter: achieve_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &achieve_journal, sizeof(struct achieve), achieve_journal_file ) )
-		{
-			int c = journal_rollforward( &achieve_journal, achieve_journal_rollforward );
-
-			printf("int_achieve: journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			achievedb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &achieve_journal );
-			journal_create( &achieve_journal, sizeof(struct achieve), achieve_journal_cache, achieve_journal_file );
-		}
+		achievedb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -282,11 +259,10 @@ int achievedb_txt_sync(void)
 	lock_fclose(fp, achieve_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( achieve_journal_enable )
+	if( achieve_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &achieve_journal );
-		journal_create( &achieve_journal, sizeof(struct achieve), achieve_journal_cache, achieve_journal_file );
+		journal_recreate( &achieve_journal, &achieve_journal_cfg, sizeof(struct achieve) );
 	}
 #endif
 
@@ -308,7 +284,7 @@ bool achievedb_txt_delete(int char_id)
 	aFree(a);
 
 #ifdef TXT_JOURNAL
-	if( achieve_journal_enable )
+	if( achieve_journal_cfg.enable )
 		journal_write( &achieve_journal, char_id, NULL );
 #endif
 
@@ -347,7 +323,7 @@ bool achievedb_txt_save(struct achieve *a2)
 		memcpy(a1, a2, sizeof(struct achieve));
 
 #ifdef TXT_JOURNAL
-	if( achieve_journal_enable )
+	if( achieve_journal_cfg.enable )
 		journal_write( &achieve_journal, a1->char_id, a1 );
 #endif
 	return true;
@@ -372,7 +348,7 @@ void achievedb_txt_final(void)
 		numdb_final(achieve_db, achievedb_txt_final_sub);
 
 #ifdef TXT_JOURNAL
-	if( achieve_journal_enable )
+	if( achieve_journal_cfg.enable )
 	{
 		journal_final( &achieve_journal );
 	}

--- a/src/char/txt/chardb_txt.c
+++ b/src/char/txt/chardb_txt.c
@@ -37,10 +37,8 @@
 #include "chardb_txt.h"
 
 #ifdef TXT_JOURNAL
-static int char_journal_enable = 1;
+static struct journal_config char_journal_cfg = { 1, "./save/auriga.journal", 1000 };
 static struct journal char_journal;
-static char char_journal_file[1024] = "./save/auriga.journal";
-static int char_journal_cache = 1000;
 #endif
 
 static struct mmo_chardata *char_dat = NULL;
@@ -59,12 +57,8 @@ int chardb_txt_config_read_sub(const char* w1,const char* w2)
 	else if( strcmpi(w1,"gm_account_filename") == 0 )
 		auriga_strlcpy(GM_account_filename, w2, sizeof(GM_account_filename));
 #ifdef TXT_JOURNAL
-	else if( strcmpi(w1,"char_journal_enable") == 0 )
-		char_journal_enable = atoi( w2 );
-	else if( strcmpi(w1,"char_journal_file") == 0 )
-		auriga_strlcpy( char_journal_file, w2, sizeof(char_journal_file) );
-	else if(strcmpi( w1,"char_journal_cache_interval") == 0 )
-		char_journal_cache = atoi( w2 );
+	else if(journal_config_read(&char_journal_cfg, "char_journal", w1, w2)) {
+	}
 #endif
 	else
 		return 0;
@@ -1017,25 +1011,11 @@ static bool chardb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( char_journal_enable )
+	if( journal_setup( &char_journal, &char_journal_cfg, sizeof(struct mmo_chardata), char_journal_rollforward, "char: journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &char_journal, sizeof(struct mmo_chardata), char_journal_file ) )
-		{
-			int c = journal_rollforward( &char_journal, char_journal_rollforward );
-
-			printf("char: journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			chardb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &char_journal );
-			journal_create( &char_journal, sizeof(struct mmo_chardata), char_journal_cache, char_journal_file );
-		}
+		chardb_txt_sync();
 	}
+
 #endif
 
 	// 友達リストの名前を解決
@@ -1087,11 +1067,10 @@ void chardb_txt_sync(void)
 	lock_fclose(fp, char_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( char_journal_enable )
+	if( char_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &char_journal );
-		journal_create( &char_journal, sizeof(struct mmo_chardata), char_journal_cache, char_journal_file );
+		journal_recreate( &char_journal, &char_journal_cfg, sizeof(struct mmo_chardata) );
 	}
 #endif
 }
@@ -1231,7 +1210,7 @@ const struct mmo_chardata *chardb_txt_make(int account_id, const unsigned char *
 	char_num++;
 
 #ifdef TXT_JOURNAL
-	if( char_journal_enable )
+	if( char_journal_cfg.enable )
 		journal_write( &char_journal, char_dat[n].st.char_id, &char_dat[n] );
 #endif
 
@@ -1290,7 +1269,7 @@ bool chardb_txt_save_reg(int account_id, int char_id, int num, struct global_reg
 			memcpy(&char_dat[idx].reg.global, reg, sizeof(char_dat[idx].reg.global));
 			char_dat[idx].reg.global_num = num;
 #ifdef TXT_JOURNAL
-			if( char_journal_enable )
+			if( char_journal_cfg.enable )
 				journal_write( &char_journal, char_id, &char_dat[idx] );
 #endif
 		}
@@ -1314,7 +1293,7 @@ bool chardb_txt_save(struct mmo_charstatus *st)
 		if(char_dat[idx].st.account_id == st->account_id) {
 			memcpy(&char_dat[idx].st, st, sizeof(struct mmo_charstatus));
 #ifdef TXT_JOURNAL
-			if( char_journal_enable )
+			if( char_journal_cfg.enable )
 				journal_write( &char_journal, st->char_id, &char_dat[idx] );
 #endif
 		}
@@ -1334,7 +1313,7 @@ bool chardb_txt_delete_sub(int char_id)
 		memset(&char_dat[idx], 0, sizeof(char_dat[0]));
 		char_dat[idx].st.char_id = char_id;	// キャラIDは維持
 #ifdef TXT_JOURNAL
-		if( char_journal_enable )
+		if( char_journal_cfg.enable )
 			journal_write( &char_journal, char_id, NULL );
 #endif
 	}
@@ -1422,7 +1401,7 @@ void chardb_txt_final(void)
 	aFree(char_dat);
 
 #ifdef TXT_JOURNAL
-	if( char_journal_enable )
+	if( char_journal_cfg.enable )
 	{
 		journal_final( &char_journal );
 	}

--- a/src/char/txt/elemdb_txt.c
+++ b/src/char/txt/elemdb_txt.c
@@ -38,10 +38,8 @@ static char elem_txt[1024] = "save/elemental.txt";
 static int elem_newid = 100;
 
 #ifdef TXT_JOURNAL
-static int elem_journal_enable = 1;
+static struct journal_config elem_journal_cfg = { 1, "./save/elemental.journal", 1000 };
 static struct journal elem_journal;
-static char elem_journal_file[1024] = "./save/elemental.journal";
-static int elem_journal_cache = 1000;
 #endif
 
 /*==========================================
@@ -54,14 +52,7 @@ int elemdb_txt_config_read_sub(const char* w1,const char *w2)
 		auriga_strlcpy(elem_txt, w2, sizeof(elem_txt));
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"elem_journal_enable")==0){
-		elem_journal_enable = atoi( w2 );
-	}
-	else if(strcmpi(w1,"elem_journal_file")==0){
-		auriga_strlcpy( elem_journal_file, w2, sizeof(elem_journal_file) );
-	}
-	else if(strcmpi(w1,"elem_journal_cache_interval")==0){
-		elem_journal_cache = atoi( w2 );
+	else if(journal_config_read(&elem_journal_cfg, "elem_journal", w1, w2)) {
 	}
 #endif
 	else {
@@ -200,25 +191,11 @@ static bool elemdb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( elem_journal_enable )
+	if( journal_setup( &elem_journal, &elem_journal_cfg, sizeof(struct mmo_elemstatus), elem_journal_rollforward, "inter: elem_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &elem_journal, sizeof(struct mmo_elemstatus), elem_journal_file ) )
-		{
-			int c = journal_rollforward( &elem_journal, elem_journal_rollforward );
-
-			printf("int_elem: journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			elemdb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &elem_journal );
-			journal_create( &elem_journal, sizeof(struct mmo_elemstatus), elem_journal_cache, elem_journal_file );
-		}
+		elemdb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -255,11 +232,10 @@ int elemdb_txt_sync(void)
 	lock_fclose(fp, elem_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( elem_journal_enable )
+	if( elem_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &elem_journal );
-		journal_create( &elem_journal, sizeof(struct mmo_elemstatus), elem_journal_cache, elem_journal_file );
+		journal_recreate( &elem_journal, &elem_journal_cfg, sizeof(struct mmo_elemstatus) );
 	}
 #endif
 
@@ -282,7 +258,7 @@ bool elemdb_txt_delete(int elem_id)
 	printf("elem_id: %d deleted\n", elem_id);
 
 #ifdef TXT_JOURNAL
-	if( elem_journal_enable )
+	if( elem_journal_cfg.enable )
 		journal_write( &elem_journal, elem_id, NULL );
 #endif
 
@@ -316,7 +292,7 @@ bool elemdb_txt_save(struct mmo_elemstatus *p2)
 	memcpy(p1, p2, sizeof(struct mmo_elemstatus));
 
 #ifdef TXT_JOURNAL
-	if( elem_journal_enable )
+	if( elem_journal_cfg.enable )
 		journal_write( &elem_journal, p1->elem_id, p1 );
 #endif
 	return true;
@@ -359,7 +335,7 @@ void elemdb_txt_final(void)
 		numdb_final(elem_db, elemdb_txt_final_sub);
 
 #ifdef TXT_JOURNAL
-	if( elem_journal_enable )
+	if( elem_journal_cfg.enable )
 	{
 		journal_final( &elem_journal );
 	}

--- a/src/char/txt/guilddb_txt.c
+++ b/src/char/txt/guilddb_txt.c
@@ -41,15 +41,11 @@ static char guild_txt[1024]  = "save/guild.txt";
 static char castle_txt[1024] = "save/castle.txt";
 
 #ifdef TXT_JOURNAL
-static int guild_journal_enable = 1;
+static struct journal_config guild_journal_cfg = { 1, "./save/guild.journal", 1000 };
 static struct journal guild_journal;
-static char guild_journal_file[1024] = "./save/guild.journal";
-static int guild_journal_cache = 1000;
 
-int guildcastle_journal_enable = 1;
+struct journal_config guildcastle_journal_cfg = { 1, "./save/castle.journal", 1000 };
 struct journal guildcastle_journal;
-static char guildcastle_journal_file[1024] = "./save/castle.journal";
-static int guildcastle_journal_cache = 1000;
 
 #endif
 
@@ -66,24 +62,12 @@ int guilddb_txt_config_read_sub(const char* w1,const char *w2)
 		auriga_strlcpy(castle_txt,w2,sizeof(castle_txt));
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"guild_journal_enable")==0){
-		guild_journal_enable = atoi( w2 );
+	else if(journal_config_read(&guild_journal_cfg, "guild_journal", w1, w2)) {
 	}
-	else if(strcmpi(w1,"guild_journal_file")==0){
-		auriga_strlcpy( guild_journal_file, w2, sizeof(guild_journal_file) );
+
+	else if(journal_config_read(&guildcastle_journal_cfg, "castle_journal", w1, w2)) {
 	}
-	else if(strcmpi(w1,"guild_journal_cache_interval")==0){
-		guild_journal_cache = atoi( w2 );
-	}
-	else if(strcmpi(w1,"castle_journal_enable")==0){
-		guildcastle_journal_enable = atoi( w2 );
-	}
-	else if(strcmpi(w1,"castle_journal_file")==0){
-		auriga_strlcpy( guildcastle_journal_file, w2, sizeof(guildcastle_journal_file) );
-	}
-	else if(strcmpi(w1,"castle_journal_cache_interval")==0){
-		guildcastle_journal_cache = atoi( w2 );
-	}
+
 #endif
 	else {
 		return 0;
@@ -438,25 +422,11 @@ static bool guilddb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( guild_journal_enable )
+	if( journal_setup( &guild_journal, &guild_journal_cfg, sizeof(struct guild), guild_journal_rollforward, "int_guild: guild_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &guild_journal, sizeof(struct guild), guild_journal_file ) )
-		{
-			int c = journal_rollforward( &guild_journal, guild_journal_rollforward );
-
-			printf("int_guild: guild_journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			guilddb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &guild_journal );
-			journal_create( &guild_journal, sizeof(struct guild), guild_journal_cache, guild_journal_file );
-		}
+		guilddb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -507,11 +477,10 @@ int guilddb_txt_sync(void)
 	lock_fclose(fp, guild_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( guild_journal_enable )
+	if( guild_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &guild_journal );
-		journal_create( &guild_journal, sizeof(struct guild), guild_journal_cache, guild_journal_file );
+		journal_recreate( &guild_journal, &guild_journal_cfg, sizeof(struct guild) );
 	}
 #endif
 
@@ -562,7 +531,7 @@ static int guilddb_txt_delete_sub(void *key, void *data, va_list ap)
 		{
 			g->alliance[i].guild_id = 0;
 #ifdef TXT_JOURNAL
-			if( guild_journal_enable )
+			if( guild_journal_cfg.enable )
 				journal_write( &guild_journal, g->guild_id, g );
 #endif
 		}
@@ -582,7 +551,7 @@ bool guilddb_txt_delete(int guild_id)
 		aFree(g);
 
 #ifdef TXT_JOURNAL
-		if( guild_journal_enable )
+		if( guild_journal_cfg.enable )
 			journal_write( &guild_journal, guild_id, NULL );
 #endif
 	}
@@ -605,7 +574,7 @@ bool guilddb_txt_new(struct guild *g2)
 	memcpy(g1, g2, sizeof(struct guild));
 	numdb_insert(guild_db, g2->guild_id, g1);
 #ifdef TXT_JOURNAL
-	if( guild_journal_enable )
+	if( guild_journal_cfg.enable )
 		journal_write( &guild_journal, g1->guild_id, g1 );
 #endif
 
@@ -629,7 +598,7 @@ bool guilddb_txt_save(struct guild* g2)
 	}
 	memcpy(g1, g2, sizeof(struct guild));
 #ifdef TXT_JOURNAL
-	if( guild_journal_enable )
+	if( guild_journal_cfg.enable )
 		journal_write( &guild_journal, g1->guild_id, g1 );
 #endif
 	return true;
@@ -765,25 +734,11 @@ static bool guildcastle_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( guildcastle_journal_enable )
+	if( journal_setup( &guildcastle_journal, &guildcastle_journal_cfg, sizeof(struct guild_castle), guildcastle_journal_rollforward, "int_guild: castle_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &guildcastle_journal, sizeof(struct guild_castle), guildcastle_journal_file ) )
-		{
-			int c = journal_rollforward( &guildcastle_journal, guildcastle_journal_rollforward );
-
-			printf("int_guild: castle_journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			guildcastle_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &guildcastle_journal );
-			journal_create( &guildcastle_journal, sizeof(struct guild_castle), guildcastle_journal_cache, guildcastle_journal_file );
-		}
+		guildcastle_txt_sync();
 	}
+
 #endif
 	return ret;
 }
@@ -810,11 +765,10 @@ static int guildcastle_txt_sync(void)
 	lock_fclose(fp, castle_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( guildcastle_journal_enable )
+	if( guildcastle_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &guildcastle_journal );
-		journal_create( &guildcastle_journal, sizeof(struct guild_castle), guildcastle_journal_cache, guildcastle_journal_file );
+		journal_recreate( &guildcastle_journal, &guildcastle_journal_cfg, sizeof(struct guild_castle) );
 	}
 #endif
 
@@ -840,11 +794,11 @@ void guilddb_txt_final(void)
 		numdb_final(guild_db, guild_txt_db_final);
 
 #ifdef TXT_JOURNAL
-	if( guild_journal_enable )
+	if( guild_journal_cfg.enable )
 	{
 		journal_final( &guild_journal );
 	}
-	if( guildcastle_journal_enable )
+	if( guildcastle_journal_cfg.enable )
 	{
 		journal_final( &guildcastle_journal );
 	}

--- a/src/char/txt/guilddb_txt.h
+++ b/src/char/txt/guilddb_txt.h
@@ -49,7 +49,7 @@ int guilddb_txt_config_read_sub(const char* w1,const char *w2);
 #define guilddb_config_read_sub guilddb_txt_config_read_sub
 
 #ifdef TXT_JOURNAL
-extern int guildcastle_journal_enable;
+extern struct journal_config guildcastle_journal_cfg;
 extern struct journal guildcastle_journal;
 #endif
 

--- a/src/char/txt/homundb_txt.c
+++ b/src/char/txt/homundb_txt.c
@@ -38,10 +38,8 @@ static char homun_txt[1024] = "save/homun.txt";
 static int homun_newid = 100;
 
 #ifdef TXT_JOURNAL
-static int homun_journal_enable = 1;
+static struct journal_config homun_journal_cfg = { 1, "./save/homun.journal", 1000 };
 static struct journal homun_journal;
-static char homun_journal_file[1024] = "./save/homun.journal";
-static int homun_journal_cache = 1000;
 #endif
 
 /*==========================================
@@ -54,14 +52,7 @@ int homundb_txt_config_read_sub(const char* w1,const char *w2)
 		auriga_strlcpy(homun_txt, w2, sizeof(homun_txt));
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"homun_journal_enable")==0){
-		homun_journal_enable = atoi( w2 );
-	}
-	else if(strcmpi(w1,"homun_journal_file")==0){
-		auriga_strlcpy( homun_journal_file, w2, sizeof(homun_journal_file) );
-	}
-	else if(strcmpi(w1,"homun_journal_cache_interval")==0){
-		homun_journal_cache = atoi( w2 );
+	else if(journal_config_read(&homun_journal_cfg, "homun_journal", w1, w2)) {
 	}
 #endif
 	else {
@@ -302,25 +293,11 @@ static bool homundb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( homun_journal_enable )
+	if( journal_setup( &homun_journal, &homun_journal_cfg, sizeof(struct mmo_homunstatus), homun_journal_rollforward, "inter: homun_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &homun_journal, sizeof(struct mmo_homunstatus), homun_journal_file ) )
-		{
-			int c = journal_rollforward( &homun_journal, homun_journal_rollforward );
-
-			printf("int_homun: journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			homundb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &homun_journal );
-			journal_create( &homun_journal, sizeof(struct mmo_homunstatus), homun_journal_cache, homun_journal_file );
-		}
+		homundb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -358,11 +335,10 @@ int homundb_txt_sync(void)
 	lock_fclose(fp, homun_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( homun_journal_enable )
+	if( homun_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &homun_journal );
-		journal_create( &homun_journal, sizeof(struct mmo_homunstatus), homun_journal_cache, homun_journal_file );
+		journal_recreate( &homun_journal, &homun_journal_cfg, sizeof(struct mmo_homunstatus) );
 	}
 #endif
 
@@ -385,7 +361,7 @@ bool homundb_txt_delete(int homun_id)
 	printf("homun_id: %d deleted\n", homun_id);
 
 #ifdef TXT_JOURNAL
-	if( homun_journal_enable )
+	if( homun_journal_cfg.enable )
 		journal_write( &homun_journal, homun_id, NULL );
 #endif
 
@@ -419,7 +395,7 @@ bool homundb_txt_save(struct mmo_homunstatus *p2)
 	memcpy(p1, p2, sizeof(struct mmo_homunstatus));
 
 #ifdef TXT_JOURNAL
-	if( homun_journal_enable )
+	if( homun_journal_cfg.enable )
 		journal_write( &homun_journal, p1->homun_id, p1 );
 #endif
 	return true;
@@ -463,7 +439,7 @@ void homundb_txt_final(void)
 		numdb_final(homun_db, homundb_txt_final_sub);
 
 #ifdef TXT_JOURNAL
-	if( homun_journal_enable )
+	if( homun_journal_cfg.enable )
 	{
 		journal_final( &homun_journal );
 	}

--- a/src/char/txt/mercdb_txt.c
+++ b/src/char/txt/mercdb_txt.c
@@ -38,10 +38,8 @@ static char merc_txt[1024] = "save/mercenary.txt";
 static int merc_newid = 100;
 
 #ifdef TXT_JOURNAL
-static int merc_journal_enable = 1;
+static struct journal_config merc_journal_cfg = { 1, "./save/mercenary.journal", 1000 };
 static struct journal merc_journal;
-static char merc_journal_file[1024] = "./save/mercenary.journal";
-static int merc_journal_cache = 1000;
 #endif
 
 /*==========================================
@@ -54,14 +52,7 @@ int mercdb_txt_config_read_sub(const char* w1,const char *w2)
 		auriga_strlcpy(merc_txt, w2, sizeof(merc_txt));
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"merc_journal_enable")==0){
-		merc_journal_enable = atoi( w2 );
-	}
-	else if(strcmpi(w1,"merc_journal_file")==0){
-		strncpy( merc_journal_file, w2, sizeof(merc_journal_file) - 1 );
-	}
-	else if(strcmpi(w1,"merc_journal_cache_interval")==0){
-		merc_journal_cache = atoi( w2 );
+	else if(journal_config_read(&merc_journal_cfg, "merc_journal", w1, w2)) {
 	}
 #endif
 	else {
@@ -216,25 +207,11 @@ static bool mercdb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( merc_journal_enable )
+	if( journal_setup( &merc_journal, &merc_journal_cfg, sizeof(struct mmo_mercstatus), merc_journal_rollforward, "inter: merc_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &merc_journal, sizeof(struct mmo_mercstatus), merc_journal_file ) )
-		{
-			int c = journal_rollforward( &merc_journal, merc_journal_rollforward );
-
-			printf("int_merc: journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			mercdb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &merc_journal );
-			journal_create( &merc_journal, sizeof(struct mmo_mercstatus), merc_journal_cache, merc_journal_file );
-		}
+		mercdb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -272,11 +249,10 @@ int mercdb_txt_sync(void)
 	lock_fclose(fp, merc_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( merc_journal_enable )
+	if( merc_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &merc_journal );
-		journal_create( &merc_journal, sizeof(struct mmo_mercstatus), merc_journal_cache, merc_journal_file );
+		journal_recreate( &merc_journal, &merc_journal_cfg, sizeof(struct mmo_mercstatus) );
 	}
 #endif
 
@@ -299,7 +275,7 @@ bool mercdb_txt_delete(int merc_id)
 	printf("merc_id: %d deleted\n", merc_id);
 
 #ifdef TXT_JOURNAL
-	if( merc_journal_enable )
+	if( merc_journal_cfg.enable )
 		journal_write( &merc_journal, merc_id, NULL );
 #endif
 
@@ -333,7 +309,7 @@ bool mercdb_txt_save(struct mmo_mercstatus *p2)
 	memcpy(p1, p2, sizeof(struct mmo_mercstatus));
 
 #ifdef TXT_JOURNAL
-	if( merc_journal_enable )
+	if( merc_journal_cfg.enable )
 		journal_write( &merc_journal, p1->merc_id, p1 );
 #endif
 	return true;
@@ -377,7 +353,7 @@ void mercdb_txt_final(void)
 		numdb_final(merc_db, mercdb_txt_final_sub);
 
 #ifdef TXT_JOURNAL
-	if( merc_journal_enable )
+	if( merc_journal_cfg.enable )
 	{
 		journal_final( &merc_journal );
 	}

--- a/src/char/txt/partydb_txt.c
+++ b/src/char/txt/partydb_txt.c
@@ -41,10 +41,8 @@ static char party_txt[1024] = "save/party.txt";
 static int party_newid=100;
 
 #ifdef TXT_JOURNAL
-static int party_journal_enable = 1;
+static struct journal_config party_journal_cfg = { 1, "./save/party.journal", 1000 };
 static struct journal party_journal;
-static char party_journal_file[1024] = "./save/party.journal";
-static int party_journal_cache = 1000;
 #endif
 
 /*==========================================
@@ -56,12 +54,8 @@ int partydb_txt_config_read_sub(const char *w1,const char *w2)
 	if( strcmpi(w1,"party_txt") == 0 )
 		auriga_strlcpy(party_txt, w2, sizeof(party_txt));
 #ifdef TXT_JOURNAL
-	else if( strcmpi(w1,"party_journal_enable") == 0 )
-		party_journal_enable = atoi( w2 );
-	else if( strcmpi(w1,"party_journal_file") == 0 )
-		auriga_strlcpy( party_journal_file, w2, sizeof(party_journal_file) );
-	else if( strcmpi(w1,"party_journal_cache_interval") == 0 )
-		party_journal_cache = atoi( w2 );
+	else if(journal_config_read(&party_journal_cfg, "party_journal", w1, w2)) {
+	}
 #endif
 	else
 		return 0;
@@ -229,25 +223,11 @@ static bool partydb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( party_journal_enable )
+	if( journal_setup( &party_journal, &party_journal_cfg, sizeof(struct party), party_journal_rollforward, "inter: party_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &party_journal, sizeof(struct party), party_journal_file ) )
-		{
-			int c = journal_rollforward( &party_journal, party_journal_rollforward );
-
-			printf("int_party: journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			partydb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &party_journal );
-			journal_create( &party_journal, sizeof(struct party), party_journal_cache, party_journal_file );
-		}
+		partydb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -285,11 +265,10 @@ int partydb_txt_sync(void)
 	lock_fclose(fp, party_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( party_journal_enable )
+	if( party_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &party_journal );
-		journal_create( &party_journal, sizeof(struct party), party_journal_cache, party_journal_file );
+		journal_recreate( &party_journal, &party_journal_cfg, sizeof(struct party) );
 	}
 #endif
 
@@ -351,7 +330,7 @@ bool partydb_txt_save(struct party *p2)
 	}
 	memcpy(p1, p2, sizeof(struct party));
 #ifdef TXT_JOURNAL
-	if( party_journal_enable )
+	if( party_journal_cfg.enable )
 		journal_write( &party_journal, p1->party_id, p1 );
 #endif
 	return true;
@@ -369,7 +348,7 @@ bool partydb_txt_delete(int party_id)
 		numdb_erase(party_db, p->party_id);
 		aFree(p);
 #ifdef TXT_JOURNAL
-		if( party_journal_enable )
+		if( party_journal_cfg.enable )
 			journal_write( &party_journal, party_id, NULL );
 #endif
 	}
@@ -387,7 +366,7 @@ bool partydb_txt_new(struct party *p)
 	p->party_id = party_newid++;
 	numdb_insert(party_db, p->party_id, p);
 #ifdef TXT_JOURNAL
-	if( party_journal_enable )
+	if( party_journal_cfg.enable )
 		journal_write( &party_journal, p->party_id, p );
 #endif
 	return true;
@@ -412,7 +391,7 @@ void partydb_txt_final(void)
 		numdb_final(party_db, partydb_txt_final_sub);
 
 #ifdef TXT_JOURNAL
-	if( party_journal_enable )
+	if( party_journal_cfg.enable )
 	{
 		journal_final( &party_journal );
 	}

--- a/src/char/txt/petdb_txt.c
+++ b/src/char/txt/petdb_txt.c
@@ -39,10 +39,8 @@ static char pet_txt[1024] = "save/pet.txt";
 static int pet_newid = 100;
 
 #ifdef TXT_JOURNAL
-static int pet_journal_enable = 1;
+static struct journal_config pet_journal_cfg = { 1, "./save/pet.journal", 1000 };
 static struct journal pet_journal;
-static char pet_journal_file[1024] = "./save/pet.journal";
-static int pet_journal_cache = 1000;
 #endif
 
 /*==========================================
@@ -55,14 +53,7 @@ int petdb_txt_config_read_sub(const char* w1,const char *w2)
 		auriga_strlcpy(pet_txt, w2, sizeof(pet_txt));
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"pet_journal_enable")==0){
-		pet_journal_enable = atoi( w2 );
-	}
-	else if(strcmpi(w1,"pet_journal_file")==0){
-		auriga_strlcpy( pet_journal_file, w2, sizeof(pet_journal_file) );
-	}
-	else if(strcmpi(w1,"pet_journal_cache_interval")==0){
-		pet_journal_cache = atoi( w2 );
+	else if(journal_config_read(&pet_journal_cfg, "pet_journal", w1, w2)) {
 	}
 #endif
 	else {
@@ -218,25 +209,11 @@ static bool petdb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( pet_journal_enable )
+	if( journal_setup( &pet_journal, &pet_journal_cfg, sizeof(struct s_pet), pet_journal_rollforward, "inter: pet_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &pet_journal, sizeof(struct s_pet), pet_journal_file ) )
-		{
-			int c = journal_rollforward( &pet_journal, pet_journal_rollforward );
-
-			printf("int_pet: journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			petdb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &pet_journal );
-			journal_create( &pet_journal, sizeof(struct s_pet), pet_journal_cache, pet_journal_file );
-		}
+		petdb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -274,11 +251,10 @@ int petdb_txt_sync(void)
 	lock_fclose(fp,pet_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( pet_journal_enable )
+	if( pet_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &pet_journal );
-		journal_create( &pet_journal, sizeof(struct s_pet), pet_journal_cache, pet_journal_file );
+		journal_recreate( &pet_journal, &pet_journal_cfg, sizeof(struct s_pet) );
 	}
 #endif
 
@@ -301,7 +277,7 @@ bool petdb_txt_delete(int pet_id)
 	printf("pet_id: %d deleted\n", pet_id);
 
 #ifdef TXT_JOURNAL
-	if( pet_journal_enable )
+	if( pet_journal_cfg.enable )
 		journal_write( &pet_journal, pet_id, NULL );
 #endif
 
@@ -335,7 +311,7 @@ bool petdb_txt_save(struct s_pet *p2)
 	memcpy(p1, p2, sizeof(struct s_pet));
 
 #ifdef TXT_JOURNAL
-	if( pet_journal_enable )
+	if( pet_journal_cfg.enable )
 		journal_write( &pet_journal, p1->pet_id, p1 );
 #endif
 	return true;
@@ -374,7 +350,7 @@ void petdb_txt_final(void)
 		numdb_final(pet_db, petdb_txt_final_sub);
 
 #ifdef TXT_JOURNAL
-	if( pet_journal_enable )
+	if( pet_journal_cfg.enable )
 	{
 		journal_final( &pet_journal );
 	}

--- a/src/char/txt/questdb_txt.c
+++ b/src/char/txt/questdb_txt.c
@@ -36,10 +36,8 @@ static char quest_txt[1024] = "save/quest.txt";
 static struct dbt *quest_db = NULL;
 
 #ifdef TXT_JOURNAL
-static int quest_journal_enable = 1;
+static struct journal_config quest_journal_cfg = { 1, "./save/quest.journal", 1000 };
 static struct journal quest_journal;
-static char quest_journal_file[1024] = "./save/quest.journal";
-static int quest_journal_cache = 1000;
 #endif
 
 /*==========================================
@@ -52,14 +50,7 @@ int questdb_txt_config_read_sub(const char *w1, const char *w2)
 		auriga_strlcpy(quest_txt, w2, sizeof(quest_txt));
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"quest_journal_enable")==0) {
-		quest_journal_enable = atoi(w2);
-	}
-	else if(strcmpi(w1,"quest_journal_file")==0) {
-		auriga_strlcpy(quest_journal_file, w2, sizeof(quest_journal_file));
-	}
-	else if(strcmpi(w1,"quest_journal_cache_interval")==0) {
-		quest_journal_cache = atoi(w2);
+	else if(journal_config_read(&quest_journal_cfg, "quest_journal", w1, w2)) {
 	}
 #endif
 	else {
@@ -220,25 +211,11 @@ static bool questdb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( quest_journal_enable )
+	if( journal_setup( &quest_journal, &quest_journal_cfg, sizeof(struct quest), quest_journal_rollforward, "inter: quest_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &quest_journal, sizeof(struct quest), quest_journal_file ) )
-		{
-			int c = journal_rollforward( &quest_journal, quest_journal_rollforward );
-
-			printf("int_quest: journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			questdb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &quest_journal );
-			journal_create( &quest_journal, sizeof(struct quest), quest_journal_cache, quest_journal_file );
-		}
+		questdb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -279,11 +256,10 @@ int questdb_txt_sync(void)
 	lock_fclose(fp, quest_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( quest_journal_enable )
+	if( quest_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &quest_journal );
-		journal_create( &quest_journal, sizeof(struct quest), quest_journal_cache, quest_journal_file );
+		journal_recreate( &quest_journal, &quest_journal_cfg, sizeof(struct quest) );
 	}
 #endif
 
@@ -305,7 +281,7 @@ bool questdb_txt_delete(int char_id)
 	aFree(q);
 
 #ifdef TXT_JOURNAL
-	if( quest_journal_enable )
+	if( quest_journal_cfg.enable )
 		journal_write( &quest_journal, char_id, NULL );
 #endif
 
@@ -344,7 +320,7 @@ bool questdb_txt_save(struct quest *q2)
 		memcpy(q1, q2, sizeof(struct quest));
 
 #ifdef TXT_JOURNAL
-	if( quest_journal_enable )
+	if( quest_journal_cfg.enable )
 		journal_write( &quest_journal, q1->char_id, q1 );
 #endif
 	return true;
@@ -369,7 +345,7 @@ void questdb_txt_final(void)
 		numdb_final(quest_db, questdb_txt_final_sub);
 
 #ifdef TXT_JOURNAL
-	if( quest_journal_enable )
+	if( quest_journal_cfg.enable )
 	{
 		journal_final( &quest_journal );
 	}

--- a/src/char/txt/statusdb_txt.c
+++ b/src/char/txt/statusdb_txt.c
@@ -39,10 +39,8 @@ static char scdata_txt[1024] = "save/scdata.txt";
 static struct dbt *scdata_db = NULL;
 
 #ifdef TXT_JOURNAL
-static int status_journal_enable = 1;
+static struct journal_config status_journal_cfg = { 1, "./save/scdata.journal", 1000 };
 static struct journal status_journal;
-static char status_journal_file[1024] = "./save/scdata.journal";
-static int status_journal_cache = 1000;
 #endif
 
 /*==========================================
@@ -55,14 +53,7 @@ int statusdb_txt_config_read_sub(const char *w1, const char *w2)
 		auriga_strlcpy(scdata_txt, w2, sizeof(scdata_txt));
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"status_journal_enable")==0) {
-		status_journal_enable = atoi(w2);
-	}
-	else if(strcmpi(w1,"status_journal_file")==0) {
-		auriga_strlcpy(status_journal_file, w2, sizeof(status_journal_file));
-	}
-	else if(strcmpi(w1,"status_journal_cache_interval")==0) {
-		status_journal_cache = atoi(w2);
+	else if(journal_config_read(&status_journal_cfg, "status_journal", w1, w2)) {
 	}
 #endif
 	else {
@@ -212,25 +203,11 @@ static bool statusdb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( status_journal_enable )
+	if( journal_setup( &status_journal, &status_journal_cfg, sizeof(struct scdata), status_journal_rollforward, "inter: status_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &status_journal, sizeof(struct scdata), status_journal_file ) )
-		{
-			int c = journal_rollforward( &status_journal, status_journal_rollforward );
-
-			printf("int_status: journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			statusdb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &status_journal );
-			journal_create( &status_journal, sizeof(struct scdata), status_journal_cache, status_journal_file );
-		}
+		statusdb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -271,11 +248,10 @@ int statusdb_txt_sync(void)
 	lock_fclose(fp, scdata_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( status_journal_enable )
+	if( status_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &status_journal );
-		journal_create( &status_journal, sizeof(struct scdata), status_journal_cache, status_journal_file );
+		journal_recreate( &status_journal, &status_journal_cfg, sizeof(struct scdata) );
 	}
 #endif
 
@@ -297,7 +273,7 @@ bool statusdb_txt_delete(int char_id)
 	aFree(sc);
 
 #ifdef TXT_JOURNAL
-	if( status_journal_enable )
+	if( status_journal_cfg.enable )
 		journal_write( &status_journal, char_id, NULL );
 #endif
 
@@ -337,7 +313,7 @@ bool statusdb_txt_save(struct scdata *sc2)
 		memcpy(sc1, sc2, sizeof(struct scdata));
 
 #ifdef TXT_JOURNAL
-	if( status_journal_enable )
+	if( status_journal_cfg.enable )
 		journal_write( &status_journal, sc1->char_id, sc1 );
 #endif
 	return true;
@@ -362,7 +338,7 @@ void statusdb_txt_final(void)
 		numdb_final(scdata_db, statusdb_txt_final_sub);
 
 #ifdef TXT_JOURNAL
-	if( status_journal_enable )
+	if( status_journal_cfg.enable )
 	{
 		journal_final( &status_journal );
 	}

--- a/src/char/txt/storagedb_txt.c
+++ b/src/char/txt/storagedb_txt.c
@@ -468,8 +468,8 @@ bool gstoragedb_txt_save(struct guild_storage *gs2, int easy)
 	}
 	memcpy(gs1, gs2, sizeof(struct guild_storage));
 #ifdef TXT_JOURNAL
-	if( storage_journal_cfg.enable )
-		journal_write( &storage_journal, gs1->guild_id, gs1 );
+	if( guild_storage_journal_cfg.enable )
+		journal_write( &guild_storage_journal, gs1->guild_id, gs1 );
 #endif
 	return true;
 }

--- a/src/char/txt/storagedb_txt.c
+++ b/src/char/txt/storagedb_txt.c
@@ -42,14 +42,10 @@ static char storage_txt[1024] = "save/storage.txt";
 static char guild_storage_txt[1024] = "save/g_storage.txt";
 
 #ifdef TXT_JOURNAL
-static int storage_journal_enable = 1;
+static struct journal_config storage_journal_cfg = { 1, "./save/storage.journal", 1000 };
 static struct journal storage_journal;
-static char storage_journal_file[1024] = "./save/storage.journal";
-static int storage_journal_cache = 1000;
-static int guild_storage_journal_enable = 1;
+static struct journal_config guild_storage_journal_cfg = { 1, "./save/g_storage.journal", 1000 };
 static struct journal guild_storage_journal;
-static char guild_storage_journal_file[1024] = "./save/g_storage.journal";
-static int guild_storage_journal_cache = 1000;
 #endif
 
 /*==========================================
@@ -65,23 +61,9 @@ int storagedb_txt_config_read_sub(const char* w1,const char* w2)
 		strncpy(guild_storage_txt, w2, sizeof(guild_storage_txt) - 1);
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"storage_journal_enable")==0){
-		storage_journal_enable = atoi( w2 );
+	else if(journal_config_read(&storage_journal_cfg, "storage_journal", w1, w2)) {
 	}
-	else if(strcmpi(w1,"storage_journal_file")==0){
-		strncpy( storage_journal_file, w2, sizeof(storage_journal_file) - 1 );
-	}
-	else if(strcmpi(w1,"storage_journal_cache_interval")==0){
-		storage_journal_cache = atoi( w2 );
-	}
-	else if(strcmpi(w1,"guild_storage_journal_enable")==0){
-		guild_storage_journal_enable = atoi( w2 );
-	}
-	else if(strcmpi(w1,"guild_storage_journal_file")==0){
-		strncpy( guild_storage_journal_file, w2, sizeof(guild_storage_journal_file) - 1 );
-	}
-	else if(strcmpi(w1,"guild_storage_journal_cache_interval")==0){
-		guild_storage_journal_cache = atoi( w2 );
+	else if(journal_config_read(&guild_storage_journal_cfg, "guild_storage_journal", w1, w2)) {
 	}
 #endif
 	else {
@@ -250,7 +232,7 @@ bool storagedb_txt_save(struct storage *s2)
 	}
 	memcpy(s1, s2, sizeof(struct storage));
 #ifdef TXT_JOURNAL
-	if( storage_journal_enable )
+	if( storage_journal_cfg.enable )
 		journal_write( &storage_journal, s1->account_id, s1 );
 #endif
 	return true;
@@ -289,11 +271,10 @@ int storagedb_txt_sync(void)
 	lock_fclose(fp, storage_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( storage_journal_enable )
+	if( storage_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &storage_journal );
-		journal_create( &storage_journal, sizeof(struct storage), storage_journal_cache, storage_journal_file );
+		journal_recreate( &storage_journal, &storage_journal_cfg, sizeof(struct storage) );
 	}
 #endif
 	return 0;
@@ -317,7 +298,7 @@ bool storagedb_txt_delete(int account_id)
 		numdb_erase(storage_db, account_id);
 		aFree(s);
 #ifdef TXT_JOURNAL
-		if( storage_journal_enable )
+		if( storage_journal_cfg.enable )
 			journal_write( &storage_journal, account_id, NULL );
 #endif
 	}
@@ -487,7 +468,7 @@ bool gstoragedb_txt_save(struct guild_storage *gs2, int easy)
 	}
 	memcpy(gs1, gs2, sizeof(struct guild_storage));
 #ifdef TXT_JOURNAL
-	if( storage_journal_enable )
+	if( storage_journal_cfg.enable )
 		journal_write( &storage_journal, gs1->guild_id, gs1 );
 #endif
 	return true;
@@ -528,12 +509,10 @@ int gstoragedb_txt_sync(void)
 	lock_fclose(fp, guild_storage_txt, &lock);
 
 #ifdef TXT_JOURNAL
-	if( guild_storage_journal_enable )
+	if( guild_storage_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &guild_storage_journal );
-		journal_create( &guild_storage_journal, sizeof(struct guild_storage),
-						 guild_storage_journal_cache, guild_storage_journal_file );
+		journal_recreate( &guild_storage_journal, &guild_storage_journal_cfg, sizeof(struct guild_storage) );
 	}
 #endif
 	return 0;
@@ -557,7 +536,7 @@ bool gstoragedb_txt_delete(int guild_id)
 		numdb_erase(gstorage_db, guild_id);
 		aFree(gs);
 #ifdef TXT_JOURNAL
-		if( guild_storage_journal_enable )
+		if( guild_storage_journal_cfg.enable )
 			journal_write( &guild_storage_journal, guild_id, NULL );
 #endif
 	}
@@ -681,25 +660,11 @@ static bool storagedb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( storage_journal_enable )
+	if( journal_setup( &storage_journal, &storage_journal_cfg, sizeof(struct storage), storage_journal_rollforward, "inter: storage_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &storage_journal, sizeof(struct storage), storage_journal_file ) )
-		{
-			int c = journal_rollforward( &storage_journal, storage_journal_rollforward );
-
-			printf("int_storage: storage_journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			storagedb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &storage_journal );
-			journal_create( &storage_journal, sizeof(struct storage), storage_journal_cache, storage_journal_file );
-		}
+		storagedb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -743,26 +708,11 @@ static bool gstoragedb_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( guild_storage_journal_enable )
+	if( journal_setup( &guild_storage_journal, &guild_storage_journal_cfg, sizeof(struct guild_storage), guild_storage_journal_rollforward, "inter: guild_storage_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &guild_storage_journal, sizeof(struct guild_storage), guild_storage_journal_file ) )
-		{
-			int c = journal_rollforward( &guild_storage_journal, guild_storage_journal_rollforward );
-
-			printf("int_storage: guild_storage_journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			gstoragedb_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &guild_storage_journal );
-			journal_create( &guild_storage_journal, sizeof(struct guild_storage),
-							 guild_storage_journal_cache, guild_storage_journal_file );
-		}
+		gstoragedb_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -787,7 +737,7 @@ void storagedb_txt_final(void)
 		numdb_final(storage_db, storage_db_final);
 
 #ifdef TXT_JOURNAL
-	if( storage_journal_enable )
+	if( storage_journal_cfg.enable )
 	{
 		journal_final( &storage_journal );
 	}
@@ -813,7 +763,7 @@ void gstoragedb_txt_final(void)
 		numdb_final(gstorage_db, gstorage_db_final);
 
 #ifdef TXT_JOURNAL
-	if( guild_storage_journal_enable )
+	if( guild_storage_journal_cfg.enable )
 	{
 		journal_final( &guild_storage_journal );
 	}

--- a/src/common/journal.c
+++ b/src/common/journal.c
@@ -500,3 +500,82 @@ int journal_rollforward( struct journal* j, int(*func)( int key, void* buf, int 
 }
 
 #endif
+
+void journal_config_init(struct journal_config *cfg, int enable, const char *file, int cache)
+{
+	if(cfg == NULL)
+		return;
+	memset(cfg, 0, sizeof(*cfg));
+	cfg->enable = enable;
+	cfg->cache = cache;
+	if(file)
+		auriga_strlcpy(cfg->file, file, sizeof(cfg->file));
+}
+
+int journal_config_read(struct journal_config *cfg, const char *prefix, const char *w1, const char *w2)
+{
+	char key[128];
+
+	if(cfg == NULL || prefix == NULL || w1 == NULL || w2 == NULL)
+		return 0;
+
+	snprintf(key, sizeof(key), "%s_enable", prefix);
+	if(strcmpi(w1, key) == 0) {
+		cfg->enable = atoi(w2);
+		return 1;
+	}
+	snprintf(key, sizeof(key), "%s_file", prefix);
+	if(strcmpi(w1, key) == 0) {
+		auriga_strlcpy(cfg->file, w2, sizeof(cfg->file));
+		return 1;
+	}
+	snprintf(key, sizeof(key), "%s_cache_interval", prefix);
+	if(strcmpi(w1, key) == 0) {
+		cfg->cache = atoi(w2);
+		return 1;
+	}
+	return 0;
+}
+
+int journal_setup(struct journal *j, const struct journal_config *cfg, size_t datasize,
+	int (*rollforward)(int key, void *buf, int flag), const char *log_tag)
+{
+	if(j == NULL || cfg == NULL || !cfg->enable)
+		return 0;
+
+	if(journal_load(j, datasize, cfg->file)) {
+		int c = journal_rollforward(j, rollforward);
+		printf("%s: roll-forward (%d)\n", log_tag ? log_tag : "journal", c);
+		return 1;
+	}
+
+	journal_final(j);
+	journal_create(j, datasize, cfg->cache, cfg->file);
+	return 0;
+}
+
+int journal_setup_with_convert(struct journal *j, const struct journal_config *cfg, size_t datasize,
+	int (*rollforward)(int key, void *buf, int flag),
+	void (*convert)(struct journal_header *jhd, void *buf), const char *log_tag)
+{
+	if(j == NULL || cfg == NULL || !cfg->enable)
+		return 0;
+
+	if(journal_load_with_convert(j, datasize, cfg->file, convert)) {
+		int c = journal_rollforward(j, rollforward);
+		printf("%s: roll-forward (%d)\n", log_tag ? log_tag : "journal", c);
+		return 1;
+	}
+
+	journal_final(j);
+	journal_create(j, datasize, cfg->cache, cfg->file);
+	return 0;
+}
+void journal_recreate(struct journal *j, const struct journal_config *cfg, size_t datasize)
+{
+	if(j == NULL || cfg == NULL || !cfg->enable)
+		return;
+
+	journal_final(j);
+	journal_create(j, datasize, cfg->cache, cfg->file);
+}

--- a/src/common/journal.c
+++ b/src/common/journal.c
@@ -499,8 +499,6 @@ int journal_rollforward( struct journal* j, int(*func)( int key, void* buf, int 
 	return c;
 }
 
-#endif
-
 void journal_config_init(struct journal_config *cfg, int enable, const char *file, int cache)
 {
 	if(cfg == NULL)
@@ -571,6 +569,7 @@ int journal_setup_with_convert(struct journal *j, const struct journal_config *c
 	journal_create(j, datasize, cfg->cache, cfg->file);
 	return 0;
 }
+
 void journal_recreate(struct journal *j, const struct journal_config *cfg, size_t datasize)
 {
 	if(j == NULL || cfg == NULL || !cfg->enable)
@@ -579,3 +578,5 @@ void journal_recreate(struct journal *j, const struct journal_config *cfg, size_
 	journal_final(j);
 	journal_create(j, datasize, cfg->cache, cfg->file);
 }
+
+#endif

--- a/src/common/journal.h
+++ b/src/common/journal.h
@@ -109,6 +109,7 @@ int journal_rollforward( struct journal* j, int(*func)( int key, void* buf, int 
 //const char* journal_get( struct journal* j, int key, int* flag );
 //int journal_delete( struct journal* j, int key );
 
+#ifdef TXT_JOURNAL
 struct journal_config {
 	int enable;
 	char file[1024];
@@ -127,5 +128,6 @@ int journal_setup_with_convert(struct journal *j, const struct journal_config *c
 
 /* Recreate empty journal after txt sync. */
 void journal_recreate(struct journal *j, const struct journal_config *cfg, size_t datasize);
+#endif /* TXT_JOURNAL */
 
 #endif

--- a/src/common/journal.h
+++ b/src/common/journal.h
@@ -109,4 +109,23 @@ int journal_rollforward( struct journal* j, int(*func)( int key, void* buf, int 
 //const char* journal_get( struct journal* j, int key, int* flag );
 //int journal_delete( struct journal* j, int key );
 
+struct journal_config {
+	int enable;
+	char file[1024];
+	int cache;
+};
+
+void journal_config_init(struct journal_config *cfg, int enable, const char *file, int cache);
+int journal_config_read(struct journal_config *cfg, const char *prefix, const char *w1, const char *w2);
+
+/* Returns 1 if roll-forward ran (caller should sync txt), 0 otherwise. */
+int journal_setup(struct journal *j, const struct journal_config *cfg, size_t datasize,
+	int (*rollforward)(int key, void *buf, int flag), const char *log_tag);
+int journal_setup_with_convert(struct journal *j, const struct journal_config *cfg, size_t datasize,
+	int (*rollforward)(int key, void *buf, int flag),
+	void (*convert)(struct journal_header *jhd, void *buf), const char *log_tag);
+
+/* Recreate empty journal after txt sync. */
+void journal_recreate(struct journal *j, const struct journal_config *cfg, size_t datasize);
+
 #endif

--- a/src/login/txt/account_txt.c
+++ b/src/login/txt/account_txt.c
@@ -34,10 +34,8 @@
 #include "account_txt.h"
 
 #ifdef TXT_JOURNAL
-static int login_journal_enable = 1;
+static struct journal_config login_journal_cfg = { 1, "./save/account.journal", 1000 };
 static struct journal login_journal;
-static char login_journal_file[1024]="./save/account.journal";
-static int login_journal_cache = 1000;
 #endif
 
 static char account_filename[1024] = "save/account.txt";
@@ -63,12 +61,9 @@ int account_txt_config_read_sub(const char* w1,const char* w2)
 	if( strcmpi(w1, "account_filename") == 0 )
 		auriga_strlcpy(account_filename, w2, sizeof(account_filename));
 #ifdef TXT_JOURNAL
-	else if( strcmpi(w1, "account_journal_enable") == 0 )
-		login_journal_enable = atoi(w2);
-	else if( strcmpi(w1, "account_journal_file") == 0 )
-		auriga_strlcpy( login_journal_file, w2, sizeof(login_journal_file) );
-	else if( strcmpi(w1, "account_journal_cache_interval") == 0 )
-		login_journal_cache = atoi(w2);
+	else if(journal_config_read(&login_journal_cfg, "account_journal", w1, w2)) {
+	}
+
 #endif
 	else
 		return 0;
@@ -293,25 +288,11 @@ static bool account_txt_read(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( login_journal_enable )
+	if( journal_setup( &login_journal, &login_journal_cfg, sizeof(struct mmo_account), login_journal_rollforward, "login_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load( &login_journal, sizeof(struct mmo_account), login_journal_file ) )
-		{
-			int c = journal_rollforward( &login_journal, login_journal_rollforward );
-
-			printf("login_journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			account_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &login_journal );
-			journal_create( &login_journal, sizeof(struct mmo_account), login_journal_cache, login_journal_file );
-		}
+		account_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -357,11 +338,10 @@ void account_txt_sync(void)
 	lock_fclose(fp, account_filename, &lock);
 
 #ifdef TXT_JOURNAL
-	if( login_journal_enable )
+	if( login_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &login_journal );
-		journal_create( &login_journal, sizeof(struct mmo_account), login_journal_cache, login_journal_file );
+		journal_recreate( &login_journal, &login_journal_cfg, sizeof(struct mmo_account) );
 	}
 #endif
 
@@ -420,7 +400,7 @@ bool account_txt_account_save(struct mmo_account *account)
 	if(idx >= 0) {
 		memcpy(&auth_dat[idx], account, sizeof(struct mmo_account));
 #ifdef TXT_JOURNAL
-		if( login_journal_enable )
+		if( login_journal_cfg.enable )
 			journal_write( &login_journal, account->account_id, account );
 #endif
 		return false;
@@ -440,7 +420,7 @@ bool account_txt_account_delete(int account_id)
 		memset(&auth_dat[idx], 0, sizeof(struct mmo_account));
 		auth_dat[idx].account_id = account_id;	// アカウントIDは維持
 #ifdef TXT_JOURNAL
-		if( login_journal_enable )
+		if( login_journal_cfg.enable )
 			journal_write( &login_journal, account_id, NULL );
 #endif
 		return false;
@@ -504,7 +484,7 @@ bool account_txt_account_new(struct mmo_account *account, const char *tmpstr)
 	auth_dat[i].account_reg2_num = 0;
 	auth_num++;
 #ifdef TXT_JOURNAL
-	if( login_journal_enable )
+	if( login_journal_cfg.enable )
 		journal_write( &login_journal, auth_dat[i].account_id, &auth_dat[i] );
 #endif
 	return true;
@@ -520,7 +500,7 @@ void account_txt_final(void)
 		aFree(auth_dat);
 
 #ifdef TXT_JOURNAL
-	if( login_journal_enable )
+	if( login_journal_cfg.enable )
 	{
 		journal_final( &login_journal );
 	}

--- a/src/map/txt/mapreg_txt.c
+++ b/src/map/txt/mapreg_txt.c
@@ -39,10 +39,8 @@ int mapreg_dirty = 0;
 char mapreg_txt[256] = "save/mapreg.txt";
 
 #ifdef TXT_JOURNAL
-static int mapreg_journal_enable = 1;
+static struct journal_config mapreg_journal_cfg = { 1, "./save/mapreg.journal", 1000 };
 static struct journal mapreg_journal;
-static char mapreg_journal_file[1024] = "./save/mapreg.journal";
-static int mapreg_journal_cache = 1000;
 
 struct mapreg_data {
 	char name[256];
@@ -61,15 +59,9 @@ int mapreg_txt_config_read_sub(const char *w1, const char *w2)
 		auriga_strlcpy(mapreg_txt, w2, sizeof(mapreg_txt));
 	}
 #ifdef TXT_JOURNAL
-	else if(strcmpi(w1,"mapreg_journal_enable") == 0) {
-		mapreg_journal_enable = atoi(w2);
+	else if(journal_config_read(&mapreg_journal_cfg, "mapreg_journal", w1, w2)) {
 	}
-	else if(strcmpi(w1,"mapreg_journal_file") == 0) {
-		auriga_strlcpy(mapreg_journal_file, w2, sizeof(mapreg_journal_file));
-	}
-	else if(strcmpi(w1,"mapreg_journal_cache_interval") == 0) {
-		mapreg_journal_cache = atoi(w2);
-	}
+
 #endif
 	else {
 		return 0;
@@ -102,7 +94,7 @@ bool mapreg_txt_setreg(int num, int val, int eternal)
 		mapreg_dirty = 1;
 
 #ifdef TXT_JOURNAL
-		if( mapreg_journal_enable ) {
+		if( mapreg_journal_cfg.enable ) {
 			if(val != 0) {
 				struct mapreg_data data;
 
@@ -150,7 +142,7 @@ bool mapreg_txt_setregstr(int num, const char *str, int eternal)
 		mapreg_dirty = 1;
 
 #ifdef TXT_JOURNAL
-		if( mapreg_journal_enable ) {
+		if( mapreg_journal_cfg.enable ) {
 			if(str && *str) {
 				struct mapreg_data data;
 
@@ -288,25 +280,11 @@ static bool mapreg_txt_load(void)
 	}
 
 #ifdef TXT_JOURNAL
-	if( mapreg_journal_enable )
+	if( journal_setup_with_convert( &mapreg_journal, &mapreg_journal_cfg, sizeof(struct mapreg_data), mapreg_journal_rollforward, mapreg_journal_convert, "map: mapreg_journal" ) )
 	{
-		// ジャーナルデータのロールフォワード
-		if( journal_load_with_convert( &mapreg_journal, sizeof(struct mapreg_data), mapreg_journal_file, mapreg_journal_convert ) )
-		{
-			int c = journal_rollforward( &mapreg_journal, mapreg_journal_rollforward );
-
-			printf("map: mapreg_journal: roll-forward (%d)\n", c );
-
-			// ロールフォワードしたので、txt データを保存する ( journal も新規作成される)
-			mapreg_txt_sync();
-		}
-		else
-		{
-			// ジャーナルを新規作成する
-			journal_final( &mapreg_journal );
-			journal_create( &mapreg_journal, sizeof(struct mapreg_data), mapreg_journal_cache, mapreg_journal_file );
-		}
+		mapreg_txt_sync();
 	}
+
 #endif
 
 	return ret;
@@ -363,11 +341,10 @@ static int mapreg_txt_sync(void)
 	mapreg_dirty = 0;
 
 #ifdef TXT_JOURNAL
-	if( mapreg_journal_enable )
+	if( mapreg_journal_cfg.enable )
 	{
 		// コミットしたのでジャーナルを新規作成する
-		journal_final( &mapreg_journal );
-		journal_create( &mapreg_journal, sizeof(struct mapreg_data), mapreg_journal_cache, mapreg_journal_file );
+		journal_recreate( &mapreg_journal, &mapreg_journal_cfg, sizeof(struct mapreg_data) );
 	}
 #endif
 
@@ -408,7 +385,7 @@ int mapreg_txt_final(void)
 		numdb_final(mapregstr_db, mapreg_txt_strdb_final);
 
 #ifdef TXT_JOURNAL
-	if( mapreg_journal_enable )
+	if( mapreg_journal_cfg.enable )
 		journal_final( &mapreg_journal );
 #endif
 


### PR DESCRIPTION
## Summary
- Issue #58 Phase 3: txt ジャーナルの enable/file/cache 設定と setup/recreate 定型を `journal.c` へ共通化
- セーブ形式・conf キー名・ジャーナル意味論は変更なし
- `master` から独立（接続共通化 / item_sql と並行マージ可）

## Test plan
- [ ] `TXT_ONLY` + `TXT_JOURNAL` ビルドが通る
- [ ] 起動時ロールフォワード / セーブ時 journal_write / sync 時 recreate が従来どおり
